### PR TITLE
Fix dice variable typo

### DIFF
--- a/src/dice/dice.ts
+++ b/src/dice/dice.ts
@@ -23,8 +23,8 @@ export class LiveDice extends Dice {
 
   doRoll() :number {
     let dValue1 = this.rollD6();
-    let dVvalue2 = this.rollD6();
-    return dValue1 + dVvalue2;;
+    let dValue2 = this.rollD6();
+    return dValue1 + dValue2;
   };
 
   private rollD6() : number {


### PR DESCRIPTION
## Summary
- fix variable name `dVvalue2` -> `dValue2` in `LiveDice`

## Testing
- `npm test` *(fails: ts-node not found)*
- `npx tsc --noEmit` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68707cbc7d54832896a8b5a0eedda25a