### PR TITLE
Add ts-node dev dependency and fix Jasmine config

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
     "jasmine-ts": "^0.3.0",
     "lodash": "^4.17.15"
   },
+  "devDependencies": {
+    "ts-node": "^10.9.2"
+  },
   "scripts": {
-    "test": "ts-node node_modules/jasmine/bin/jasmine --config=jasmine.json"
+    "test": "ts-node node_modules/jasmine/bin/jasmine --config=spec/support/jasmine.json"
   }
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,7 +1,7 @@
 {
-  "spec_dir": "bin/spec",
+  "spec_dir": "spec",
   "spec_files": [
-    "**/*spec.js"
+    "**/*-spec.ts"
   ],
   "stopSpecOnExpectationFailure": false,
   "random": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "target": "esnext",
         "alwaysStrict": true,
-        "watch": true,
         "module": "commonjs",
         "outDir": "bin"
     }


### PR DESCRIPTION
## Summary
- add `ts-node` dev dependency
- set test script to use `spec/support/jasmine.json`
- update Jasmine config for TS specs
- remove invalid watch option from tsconfig

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687088a32c3c8328aa98fb6983aafbd1