### PR TITLE
Add strategy DSL scaffolding

### DIFF
--- a/spec/dsl/diff-bets-spec.ts
+++ b/spec/dsl/diff-bets-spec.ts
@@ -1,0 +1,15 @@
+import { SimpleBetReconciler, diffBets } from '../../src/dsl/bet-reconciler';
+
+describe('diffBets', () => {
+  it('creates place and odds commands for desired bets', () => {
+    const reconciler = new SimpleBetReconciler();
+    reconciler.passLine(10).withOdds(5);
+    reconciler.place(6, 12);
+    const cmds = diffBets([], reconciler.desired);
+    expect(cmds).toEqual([
+      { type: 'place', betType: 'passLine', amount: 10, point: undefined },
+      { type: 'updateOdds', betType: 'passLine', amount: 5, point: undefined },
+      { type: 'place', betType: 'place', amount: 12, point: 6 }
+    ]);
+  });
+});

--- a/spec/dsl/game-state-spec.ts
+++ b/spec/dsl/game-state-spec.ts
@@ -1,0 +1,31 @@
+import { GameState } from '../../src/dsl/game-state';
+import { Dice } from '../../src/dice/dice';
+
+class StubDice implements Dice {
+  rollHistory: number[] = [];
+  constructor(private values: number[]) {}
+  roll() {
+    const v = this.values.shift()!;
+    this.rollHistory.push(v);
+    return v;
+  }
+}
+
+describe('GameState', () => {
+  it('establishes and clears the point with events', () => {
+    const dice = new StubDice([4, 7]);
+    const game = new GameState(dice);
+    let established = 0;
+    let cleared = 0;
+    game.onPointEstablished(v => { established = v; });
+    game.onPointCleared(v => { cleared = v; });
+
+    expect(game.point).toBeNull();
+    game.roll();
+    expect(established).toBe(4);
+    expect(game.point).toBe(4);
+    game.roll();
+    expect(cleared).toBe(7);
+    expect(game.point).toBeNull();
+  });
+});

--- a/spec/dsl/reconcile-engine-spec.ts
+++ b/spec/dsl/reconcile-engine-spec.ts
@@ -1,0 +1,20 @@
+import { ReconcileEngine } from '../../src/dsl/strategy';
+import { PlayerState } from '../../src/dsl/player-state';
+import { GameState } from '../../src/dsl/game-state';
+import { PassLineAndPlace68 } from '../../src/dsl/strategies';
+import { Dice } from '../../src/dice/dice';
+
+class StubDice implements Dice {
+  rollHistory: number[] = [];
+  constructor(private values: number[]) {}
+  roll() { return this.values.shift()!; }
+}
+
+describe('ReconcileEngine', () => {
+  it('produces commands from a strategy', () => {
+    const player: PlayerState = { comeBets: [], placeBets: {} } as any;
+    const engine = new ReconcileEngine(player, new GameState(new StubDice([2])));
+    const cmds = engine.reconcile(PassLineAndPlace68);
+    expect(cmds.length).toBe(4);
+  });
+});

--- a/src/dsl/bet-reconciler.ts
+++ b/src/dsl/bet-reconciler.ts
@@ -1,0 +1,92 @@
+import { BaseBet, OddsBet, ComeBet } from './player-state';
+
+export interface BetWithOdds {
+  withOdds(amount: number): void;
+  withMaxOdds(): void;
+}
+
+export interface BetReconciler {
+  passLine(amount: number): BetWithOdds;
+  come(amount: number): BetWithOdds;
+  place(point: number, amount: number): void;
+  field(amount: number): void;
+  hardways(point: number, amount: number): void;
+  remove(type: string, point?: number): void;
+}
+
+interface DesiredBet {
+  type: string;
+  amount: number;
+  point?: number;
+  odds?: number;
+}
+
+export class SimpleBetReconciler implements BetReconciler {
+  readonly desired: DesiredBet[] = [];
+
+  private add(type: string, amount: number, point?: number): BetWithOdds {
+    const bet: DesiredBet = { type, amount, point };
+    this.desired.push(bet);
+    return {
+      withOdds: (odds: number) => { bet.odds = odds; },
+      withMaxOdds: () => { /* noop for now */ },
+    };
+  }
+
+  passLine(amount: number): BetWithOdds {
+    return this.add('passLine', amount);
+  }
+
+  come(amount: number): BetWithOdds {
+    return this.add('come', amount);
+  }
+
+  place(point: number, amount: number): void {
+    this.add('place', amount, point);
+  }
+
+  field(amount: number): void {
+    this.add('field', amount);
+  }
+
+  hardways(point: number, amount: number): void {
+    this.add('hardways', amount, point);
+  }
+
+  remove(type: string, point?: number): void {
+    this.desired.push({ type: `remove:${type}`, amount: 0, point });
+  }
+}
+
+export function diffBets(current: DesiredBet[], desired: DesiredBet[]): BetCommand[] {
+  const commands: BetCommand[] = [];
+  const key = (b: DesiredBet) => `${b.type}:${b.point ?? ''}`;
+  const currentMap = new Map(current.map(b => [key(b), b]));
+  const desiredMap = new Map(desired.map(b => [key(b), b]));
+
+  // removals
+  for (const [k, cb] of currentMap) {
+    if (!desiredMap.has(k)) {
+      commands.push({ type: 'remove', betType: cb.type, point: cb.point });
+    }
+  }
+
+  // additions / updates
+  for (const [k, db] of desiredMap) {
+    const cb = currentMap.get(k);
+    if (!cb) {
+      commands.push({ type: 'place', betType: db.type, amount: db.amount, point: db.point });
+      if (db.odds) {
+        commands.push({ type: 'updateOdds', betType: db.type, amount: db.odds, point: db.point });
+      }
+    } else if (cb.amount !== db.amount || cb.odds !== db.odds) {
+      commands.push({ type: 'updateOdds', betType: db.type, amount: db.odds ?? 0, point: db.point });
+    }
+  }
+  return commands;
+}
+
+export type BetCommand =
+  | { type: 'place'; betType: string; amount: number; point?: number }
+  | { type: 'remove'; betType: string; point?: number }
+  | { type: 'updateOdds'; betType: string; amount: number; point?: number };

--- a/src/dsl/game-state.ts
+++ b/src/dsl/game-state.ts
@@ -1,0 +1,37 @@
+import { Dice, LiveDice } from '../dice/dice';
+
+export type RollListener = (roll: number) => void;
+
+export class GameState {
+  point: number | null = null;
+  dice: Dice;
+
+  private rollListeners: RollListener[] = [];
+  private pointEstablishedListeners: RollListener[] = [];
+  private pointClearedListeners: RollListener[] = [];
+
+  constructor(dice: Dice = new LiveDice()) {
+    this.dice = dice;
+  }
+
+  roll(): number {
+    const value = this.dice.roll();
+    this.rollListeners.forEach(l => l(value));
+    if (this.point === null) {
+      if ([4,5,6,8,9,10].includes(value)) {
+        this.point = value;
+        this.pointEstablishedListeners.forEach(l => l(value));
+      }
+    } else {
+      if (value === 7 || value === this.point) {
+        this.point = null;
+        this.pointClearedListeners.forEach(l => l(value));
+      }
+    }
+    return value;
+  }
+
+  onRoll(l: RollListener): void { this.rollListeners.push(l); }
+  onPointEstablished(l: RollListener): void { this.pointEstablishedListeners.push(l); }
+  onPointCleared(l: RollListener): void { this.pointClearedListeners.push(l); }
+}

--- a/src/dsl/player-state.ts
+++ b/src/dsl/player-state.ts
@@ -1,0 +1,11 @@
+export interface BaseBet { amount: number; }
+export interface OddsBet { amount: number; point: number; }
+export interface ComeBet { base: BaseBet; odds?: OddsBet; point: number; }
+
+export interface PlayerState {
+  passLine?: BaseBet;
+  passLineOdds?: OddsBet;
+  comeBets: ComeBet[];
+  unresolvedCome?: BaseBet;
+  placeBets: Record<number, BaseBet>;
+}

--- a/src/dsl/strategies.ts
+++ b/src/dsl/strategies.ts
@@ -1,0 +1,25 @@
+import { StrategyDefinition } from './strategy';
+
+export const PassLineAnd2Comes: StrategyDefinition = ({ bets }) => {
+  bets.passLine(10).withOdds(50);
+  bets.come(10).withOdds(50);
+  bets.come(10).withOdds(50);
+};
+
+export const PassLineAndPlace68: StrategyDefinition = ({ bets }) => {
+  bets.passLine(10).withOdds(50);
+  bets.place(6, 12);
+  bets.place(8, 12);
+};
+
+export const SixIn8Progressive: StrategyDefinition = ({ bets, track }) => {
+  const wins = track<number>('wins', 0);
+  bets.place(6, 12);
+  if (wins === 1) {
+    bets.remove('place', 6);
+    bets.place(6, 24);
+  } else if (wins > 1) {
+    bets.remove('place', 6);
+    bets.place(6, 12);
+  }
+};

--- a/src/dsl/strategy.ts
+++ b/src/dsl/strategy.ts
@@ -1,0 +1,30 @@
+import { SimpleBetReconciler, BetReconciler, BetCommand, diffBets } from './bet-reconciler';
+import { PlayerState } from './player-state';
+import { GameState } from './game-state';
+
+export type StrategyDefinition = (ctx: StrategyContext) => void;
+
+export interface StrategyContext {
+  bets: BetReconciler;
+  track: <T>(key: string, initial?: T) => T;
+}
+
+export class ReconcileEngine {
+  private trackers = new Map<string, any>();
+
+  constructor(private player: PlayerState, private game: GameState) {}
+
+  reconcile(strategy: StrategyDefinition): BetCommand[] {
+    const reconciler = new SimpleBetReconciler();
+    const ctx: StrategyContext = {
+      bets: reconciler,
+      track: <T>(key: string, initial?: T) => {
+        if (!this.trackers.has(key)) this.trackers.set(key, initial);
+        return this.trackers.get(key);
+      },
+    };
+    strategy(ctx);
+    const current: any[] = [];
+    return diffBets(current, reconciler.desired);
+  }
+}


### PR DESCRIPTION
## Summary
- add GameState class with event hooks
- add PlayerState interfaces and betting definitions
- scaffold BetReconciler for collecting desired bets
- implement reconciliation engine and example strategies
- add Jasmine tests for DSL components

## Testing
- `npm test` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870828e3bc08328abd217f800a1f33b