### PR TITLE
Add oddsWorking support to ComeBet for come-out rolls

### DIFF
--- a/spec/engine/come-bet-engine-spec.ts
+++ b/spec/engine/come-bet-engine-spec.ts
@@ -1,0 +1,180 @@
+import { CrapsEngine } from '../../src/engine/craps-engine';
+import { ComeBet } from '../../src/bets/come-bet';
+import { CrapsTable } from '../../src/craps-table';
+import { RiggedDice } from '../dice/rigged-dice';
+import { StrategyDefinition } from '../../src/dsl/strategy';
+
+// ---------------------------------------------------------------------------
+// Engine integration tests — come bet bankroll settlement
+//
+// These tests verify that the engine's settleBets() method correctly credits
+// the player's bankroll for every come bet resolution scenario, including the
+// come-out push (odds OFF, returned intact) that the unit tests cannot cover.
+//
+// Test parameters (flat come-bet-odds.md §§1–7 standing values):
+//   flat wager : $10  (come bet amount)
+//   come point : 9    (3:2 true-odds multiplier)
+//   odds wager : $50  (oddsAmount; varies per test)
+// ---------------------------------------------------------------------------
+
+// Must match CrapsEngine's private playerId field.
+const PLAYER_ID = 'engine-player';
+
+const FLAT = 10;
+const ODDS = 50;
+const STARTING_BANKROLL = 200;
+// Bankroll remaining after $10 flat + $50 odds are placed:
+const AFTER_PLACEMENT = STARTING_BANKROLL - FLAT - ODDS; // 140
+
+// ---------------------------------------------------------------------------
+// Test helper
+//
+// Creates a CrapsEngine pre-loaded with an established come bet at point 9.
+// The engine's running bankroll is reduced to reflect what was spent to place
+// the flat bet and odds during the earlier (simulated) point-phase roll.
+//
+// The strategy declares the established bet each pre-roll reconciliation so
+// the reconciler does not generate a remove command for it.
+// ---------------------------------------------------------------------------
+
+function makeEngine(options: {
+  dice: number[];
+  oddsAmount?: number;
+  oddsWorking?: boolean;
+  tablePoint?: number; // undefined → come-out (point OFF); set → point ON
+}): { engine: CrapsEngine; comeBet: ComeBet } {
+  const oddsAmount = options.oddsAmount ?? ODDS;
+  const oddsWorking = options.oddsWorking ?? false;
+
+  // Create the bet first so the strategy closure can reference it.
+  const comeBet = new ComeBet(FLAT, PLAYER_ID);
+  comeBet.point = 9;
+  comeBet.oddsAmount = oddsAmount;
+  comeBet.oddsWorking = oddsWorking;
+
+  // Declare the established come bet in the reconciler's desired list so the
+  // reconciler treats it as intentional and does not remove it before the roll.
+  const strategy: StrategyDefinition = (ctx) => {
+    (ctx.bets as any).desired.push({
+      type: 'come',
+      amount: comeBet.amount,
+      point: comeBet.point,
+      odds: comeBet.oddsAmount,
+    });
+  };
+
+  const engine = new CrapsEngine({
+    strategy,
+    bankroll: STARTING_BANKROLL,
+    rolls: options.dice.length,
+    dice: new RiggedDice(options.dice),
+  });
+
+  // Wire in the pre-established come bet and set the table point.
+  const table: CrapsTable = (engine as any).table;
+  table.currentPoint = options.tablePoint;
+  table.placeBet(comeBet);
+
+  // Reflect the original placement cost in the engine's running bankroll.
+  (engine as any).bankroll -= (FLAT + oddsAmount);
+
+  return { engine, comeBet };
+}
+
+// ---------------------------------------------------------------------------
+// Come-out roll — odds OFF (default)
+// Table point is undefined (OFF); come bet is established at 9 with $50 odds.
+// ---------------------------------------------------------------------------
+
+describe('CrapsEngine — come bet bankroll settlement', () => {
+
+  describe('come-out roll, odds OFF (default)', () => {
+
+    // §§3.1–3.3, §6.2: seven during come-out → flat loses, odds pushed.
+    // The engine must return the $50 odds to bankroll even though payOut is
+    // undefined (this is the push path, not the win path).
+    it('should return odds to bankroll when come-out 7 pushes the odds', () => {
+      const { engine } = makeEngine({ dice: [7] }); // come-out (tablePoint: undefined)
+
+      // Come-out 7 with odds OFF:
+      //   flat $10 lost (already deducted at placement)
+      //   odds $50 returned as push
+      // Bankroll: 140 + 50 = 190
+      const result = engine.run();
+      expect(result.finalBankroll).toBe(190);
+    });
+
+    // §§2.1–2.3: own-point during come-out → flat wins 1:1, odds returned.
+    // payOut = $10 (flat only). Settlement path: bankroll += amount + oddsAmount + payOut.
+    it('should credit flat win + return odds when come-out own-point hits', () => {
+      const { engine } = makeEngine({ dice: [9] }); // come-out, own point
+
+      // Come-out 9 (own point) with odds OFF:
+      //   flat $10 wins 1:1 → payOut = 10
+      //   odds $50 returned (not paid)
+      // Settlement: amount(10) + oddsAmount(50) + payOut(10) = 70
+      // Bankroll: 140 + 70 = 210
+      const result = engine.run();
+      expect(result.finalBankroll).toBe(210);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Come-out roll — odds WORKING (§5)
+  // Player has declared odds working; they are live during the come-out roll.
+  // ---------------------------------------------------------------------------
+
+  describe('come-out roll, odds WORKING', () => {
+
+    // §5.2: own-point + odds working → flat wins 1:1, odds win at true odds.
+    // Point 9 pays 3:2: $50 odds → $75 profit. payOut = $10 + $75 = $85.
+    it('should pay flat 1:1 + true odds when come-out own-point hits with odds working', () => {
+      const { engine } = makeEngine({ dice: [9], oddsWorking: true });
+
+      // payOut = 10 (flat) + 75 (3:2 on $50) = 85
+      // Settlement: amount(10) + oddsAmount(50) + payOut(85) = 145
+      // Bankroll: 140 + 145 = 285
+      const result = engine.run();
+      expect(result.finalBankroll).toBe(285);
+    });
+
+    // §5.3: seven + odds working → flat loses AND odds lose.
+    it('should lose both flat and odds when come-out 7 with odds working', () => {
+      const { engine } = makeEngine({ dice: [7], oddsWorking: true });
+
+      // lose() → amount=0, oddsAmount=0. Nothing returned.
+      // Bankroll: 140 (no change)
+      const result = engine.run();
+      expect(result.finalBankroll).toBe(140);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Point phase (table point ON)
+  // Come bet is established at 9 while the table point is at 6.
+  // ---------------------------------------------------------------------------
+
+  describe('point phase (table point ON)', () => {
+
+    // True-odds win: come bet's own point (9, 3:2) overrides table point (6, 6:5).
+    it('should pay true odds based on come bet own point (9, 3:2) not table point (6, 6:5)', () => {
+      const { engine } = makeEngine({ dice: [9], tablePoint: 6 });
+
+      // win(table): payOut = 10 (flat) + floor(50/2)*3 = 10 + 75 = 85
+      // Settlement: amount(10) + oddsAmount(50) + payOut(85) = 145
+      // Bankroll: 140 + 145 = 285
+      const result = engine.run();
+      expect(result.finalBankroll).toBe(285);
+    });
+
+    // Seven-out: both flat and odds are forfeited (odds were active).
+    it('should lose both flat and odds on seven-out', () => {
+      const { engine } = makeEngine({ dice: [7], tablePoint: 6 });
+
+      // lose() → amount=0, oddsAmount=0. Nothing returned.
+      // Bankroll: 140 (no change)
+      const result = engine.run();
+      expect(result.finalBankroll).toBe(140);
+    });
+  });
+});

--- a/src/bets/come-bet.ts
+++ b/src/bets/come-bet.ts
@@ -23,6 +23,26 @@ export class ComeBet extends PassLineBet {
     return cb.isOkayToPlace(table);
   }
 
+  // Override: compute odds from this.point (the come bet's own point),
+  // not table.currentPoint. Also applies during come-out when oddsWorking=true,
+  // so we guard on this.point !== undefined rather than table.isPointOn.
+  win(table: CrapsTable): void {
+    this.payOut = this.amount;
+    if (this.point !== undefined) {
+      this.payOut += ComeBet.computeOddsPayoutForPoint(this.oddsAmount, this.point);
+    }
+  }
+
+  private static computeOddsPayoutForPoint(oddsAmount: number, point: number): number {
+    if (!oddsAmount) return 0;
+    switch (point) {
+      case 4: case 10: return oddsAmount * 2;
+      case 5: case 9:  return Math.floor(oddsAmount / 2) * 3;
+      case 6: case 8:  return Math.floor(oddsAmount / 5) * 6;
+      default:         return 0;
+    }
+  }
+
   evaluateDiceRoll(diceRoll: DiceRoll, table: CrapsTable): void {
     const rollValue = diceRoll.sum;
 
@@ -57,19 +77,30 @@ export class ComeBet extends PassLineBet {
           // Normal point-phase win: base pays 1:1, odds pay true odds.
           this.win(table);
         } else {
-          // Come-out: own point rolled while odds are OFF.
-          // Base wins 1:1; odds returned (not paid, not lost).
-          this.payOut = this.amount;
-          // oddsAmount preserved — returned to player, not paid as winnings.
+          // Come-out: own point rolled.
+          if (this.oddsWorking) {
+            // Odds declared working: flat 1:1 + true odds (§5.2).
+            this.win(table);
+          } else {
+            // Odds OFF (default): base wins 1:1, odds returned intact (§2.1–2.3).
+            this.payOut = this.amount;
+            // oddsAmount preserved — returned to player, not paid as winnings.
+          }
         }
       } else if (rollValue === 7) {
         if (table.isPointOn) {
           // Seven-out: base AND odds both lose.
           this.lose();
         } else {
-          // Come-out 7: base loses, odds are OFF and returned to player.
-          this.amount = 0;
-          // oddsAmount intentionally preserved — odds were not at risk.
+          // Come-out 7.
+          if (this.oddsWorking) {
+            // Odds declared working: both flat and odds lose (§5.3).
+            this.lose();
+          } else {
+            // Odds OFF (default): base loses, odds returned intact (§3.1–3.3).
+            this.amount = 0;
+            // oddsAmount intentionally preserved — odds were not at risk.
+          }
         }
       }
     }

--- a/src/engine/craps-engine.ts
+++ b/src/engine/craps-engine.ts
@@ -304,6 +304,13 @@ export class CrapsEngine {
         if (bet instanceof DontPassBet) bet.layOddsAmount = 0;
 
         this.table.removeBet(bet);
+      } else if (bet instanceof ComeBet && bet.amount === 0 && bet.oddsAmount > 0) {
+        // Come-out push (§§3.1–3.3): flat bet lost during come-out while odds
+        // were OFF.  evaluateDiceRoll preserved oddsAmount intact (not at risk);
+        // the bet was already removed from the table by resolveBets (amount===0).
+        // Credit the odds back to bankroll without recording a win.
+        this.bankroll += bet.oddsAmount;
+        bet.oddsAmount = 0;
       }
       // Lost bets: already removed by resolveBets, bankroll was deducted at placement
     }


### PR DESCRIPTION
## Summary
This PR adds support for the `oddsWorking` flag in ComeBet, allowing come bet odds to be declared "working" during come-out rolls. Previously, come bet odds were always off during come-out, but this change enables players to have their odds participate in come-out outcomes when explicitly declared.

## Key Changes
- **New `win()` method override**: Computes odds payouts based on the come bet's own point rather than the table's current point, enabling correct payout calculation when odds are working during come-out.
- **New `computeOddsPayoutForPoint()` helper**: Extracted odds payout calculation logic to compute true odds for any given point (4/10: 2:1, 5/9: 3:2, 6/8: 6:5).
- **Come-out point roll handling**: When a come bet's own point is rolled during come-out:
  - If `oddsWorking=true`: Both base and odds win with true odds payout (§5.2)
  - If `oddsWorking=false` (default): Base wins 1:1, odds are returned intact (§2.1–2.3)
- **Come-out 7 handling**: When 7 is rolled during come-out:
  - If `oddsWorking=true`: Both base and odds lose (§5.3)
  - If `oddsWorking=false` (default): Base loses, odds are returned intact (§3.1–3.3)

## Implementation Details
- The `win()` override guards on `this.point !== undefined` rather than `table.isPointOn` to correctly handle come-out scenarios where the come bet has its own point.
- Odds payout calculations use floor division to ensure proper rounding for fractional odds (e.g., 3:2 and 6:5).
- Comments reference specific rule sections (§) for clarity on come bet odds behavior.

https://claude.ai/code/session_01T5fabqEnhm25zJiGmXNW6h