### PR TITLE
Add push outcome tracking for craps bets with special conditions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "craps",
       "dependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",

--- a/src/dsl/outcome.ts
+++ b/src/dsl/outcome.ts
@@ -1,7 +1,7 @@
 import { BetTypes } from '../bets/base-bet';
 
 export interface Outcome {
-  result: 'win' | 'loss';
+  result: 'win' | 'loss' | 'push';
   betType: BetTypes;
   point?: number;
   amount: number;

--- a/src/engine/craps-engine.ts
+++ b/src/engine/craps-engine.ts
@@ -261,7 +261,7 @@ export class CrapsEngine {
 
   private collectOutcomes(snapshots: BetSnapshot[]): Outcome[] {
     const outcomes: Outcome[] = [];
-    for (const { bet, amount } of snapshots) {
+    for (const { bet, amount, oddsAmount } of snapshots) {
       if ((bet.payOut ?? 0) > 0) {
         outcomes.push({
           result: 'win',
@@ -269,6 +269,16 @@ export class CrapsEngine {
           point: bet.point,
           amount,
           payout: bet.payOut ?? 0,
+        });
+      } else if (bet instanceof DontPassBet && bet.payOut === 0 && bet.amount === 0) {
+        // DontCome bar-12 transit push: payOut explicitly set to 0 (not undefined, which
+        // signals a loss from lose()). The flat stake is returned intact — no win, no loss.
+        outcomes.push({
+          result: 'push',
+          betType: bet.betType,
+          point: bet.point,
+          amount,
+          payout: 0,
         });
       } else if (bet.amount === 0) {
         outcomes.push({
@@ -278,6 +288,17 @@ export class CrapsEngine {
           amount,
           payout: 0,
         });
+        // ComeBet seven-out with odds OFF: flat is lost (above), but odds were never
+        // at risk — they are returned to the player. Record as a separate push outcome.
+        if (bet instanceof ComeBet && oddsAmount > 0) {
+          outcomes.push({
+            result: 'push',
+            betType: bet.betType,
+            point: bet.point,
+            amount: oddsAmount,
+            payout: 0,
+          });
+        }
       }
     }
     return outcomes;

--- a/src/engine/shared-table.ts
+++ b/src/engine/shared-table.ts
@@ -292,7 +292,7 @@ export class SharedTable {
 
   private collectOutcomes(snapshots: BetSnapshot[]): Outcome[] {
     const outcomes: Outcome[] = [];
-    for (const { bet, amount } of snapshots) {
+    for (const { bet, amount, oddsAmount } of snapshots) {
       if ((bet.payOut ?? 0) > 0) {
         outcomes.push({
           result: 'win',
@@ -300,6 +300,16 @@ export class SharedTable {
           point: bet.point,
           amount,
           payout: bet.payOut ?? 0,
+        });
+      } else if (bet instanceof DontPassBet && bet.payOut === 0 && bet.amount === 0) {
+        // DontCome bar-12 transit push: payOut explicitly set to 0 (not undefined, which
+        // signals a loss from lose()). The flat stake is returned intact — no win, no loss.
+        outcomes.push({
+          result: 'push',
+          betType: bet.betType,
+          point: bet.point,
+          amount,
+          payout: 0,
         });
       } else if (bet.amount === 0) {
         outcomes.push({
@@ -309,6 +319,17 @@ export class SharedTable {
           amount,
           payout: 0,
         });
+        // ComeBet seven-out with odds OFF: flat is lost (above), but odds were never
+        // at risk — they are returned to the player. Record as a separate push outcome.
+        if (bet instanceof ComeBet && oddsAmount > 0) {
+          outcomes.push({
+            result: 'push',
+            betType: bet.betType,
+            point: bet.point,
+            amount: oddsAmount,
+            payout: 0,
+          });
+        }
       }
     }
     return outcomes;

--- a/src/logger/run-logger.ts
+++ b/src/logger/run-logger.ts
@@ -59,9 +59,11 @@ export interface SummaryRecord {
   activity: {
     rollsWithWin: number;
     rollsWithLoss: number;
+    rollsWithPush: number;
     rollsNoAction: number;
     winRate: number;
     lossRate: number;
+    pushRate: number;
   };
   diceDistribution: {
     bySum: Record<string, number>;
@@ -81,6 +83,8 @@ export class RunLogger {
   private maxDrawdown = 0;
   private rollsWithWin = 0;
   private rollsWithLoss = 0;
+  private rollsWithPush = 0;
+  private rollsNoAction = 0;
   private totalTableLoad = 0;
   private maxTableLoad = 0;
   private minTableLoad = Infinity;
@@ -158,11 +162,16 @@ export class RunLogger {
     const drawdown = this.lastPeak - record.bankrollAfter;
     if (drawdown > this.maxDrawdown) this.maxDrawdown = drawdown;
 
-    // Activity
+    // Activity — each flag is independent; a roll can count in multiple categories
+    // (e.g. loss + push on a ComeBet seven-out with odds OFF). noAction is strict:
+    // only rolls with zero outcomes of any kind.
     const hasWin = record.outcomes.some(o => o.result === 'win');
     const hasLoss = record.outcomes.some(o => o.result === 'loss');
+    const hasPush = record.outcomes.some(o => o.result === 'push');
     if (hasWin) this.rollsWithWin++;
     if (hasLoss) this.rollsWithLoss++;
+    if (hasPush) this.rollsWithPush++;
+    if (!hasWin && !hasLoss && !hasPush) this.rollsNoAction++;
 
     // Table load
     const load = record.tableLoadBefore;
@@ -189,7 +198,6 @@ export class RunLogger {
 
   buildSummary(): SummaryRecord {
     const totalRolls = this.rollEntries.length;
-    const rollsNoAction = totalRolls - this.rollsWithWin - this.rollsWithLoss;
     const avgTableLoad = totalRolls > 0 ? this.totalTableLoad / totalRolls : 0;
     const avgWhenActive = this.rollsWithActiveBets > 0
       ? this.totalTableLoadWhenActive / this.rollsWithActiveBets
@@ -220,9 +228,11 @@ export class RunLogger {
       activity: {
         rollsWithWin: this.rollsWithWin,
         rollsWithLoss: this.rollsWithLoss,
-        rollsNoAction,
+        rollsWithPush: this.rollsWithPush,
+        rollsNoAction: this.rollsNoAction,
         winRate: totalRolls > 0 ? round4(this.rollsWithWin / totalRolls) : 0,
         lossRate: totalRolls > 0 ? round4(this.rollsWithLoss / totalRolls) : 0,
+        pushRate: totalRolls > 0 ? round4(this.rollsWithPush / totalRolls) : 0,
       },
       diceDistribution: {
         bySum: { ...this.bySum },
@@ -287,6 +297,7 @@ export class RunLogger {
     console.log('');
     console.log(`Win rolls:    ${a.rollsWithWin} (${(a.winRate * 100).toFixed(1)}%)`);
     console.log(`Loss rolls:   ${a.rollsWithLoss} (${(a.lossRate * 100).toFixed(1)}%)`);
+    console.log(`Push rolls:   ${a.rollsWithPush} (${(a.pushRate * 100).toFixed(1)}%)`);
     console.log(`No action:    ${a.rollsNoAction}`);
     console.log('');
     console.log(`Table load:   avg $${tl.avg}  max $${tl.max}  avg-when-active $${tl.avgWhenActive}`);

--- a/types/simulation.ts
+++ b/types/simulation.ts
@@ -11,7 +11,7 @@ export interface ActiveBetInfo {
 }
 
 export interface Outcome {
-  result: 'win' | 'loss';
+  result: 'win' | 'loss' | 'push';
   betType: number;
   point?: number;
   amount: number;
@@ -67,9 +67,11 @@ export interface SummaryRecord {
   activity: {
     rollsWithWin: number;
     rollsWithLoss: number;
+    rollsWithPush: number;
     rollsNoAction: number;
     winRate: number;
     lossRate: number;
+    pushRate: number;
   };
   diceDistribution: {
     bySum: Record<string, number>;

--- a/web/src/components/SummaryPanel.tsx
+++ b/web/src/components/SummaryPanel.tsx
@@ -26,6 +26,7 @@ export function SummaryPanel({ result, params }: Props) {
         <StatCard label="Total Rolls" value={String(stats.totalRolls)} />
         <StatCard label="Win Rolls" value={String(stats.winRolls)} />
         <StatCard label="Loss Rolls" value={String(stats.lossRolls)} />
+        <StatCard label="Push Rolls" value={String(stats.pushRolls)} />
         <StatCard label="No Action" value={String(stats.noActionRolls)} />
         <StatCard label="Avg Table Load" value={`$${stats.avgTableLoad}`} />
       </div>

--- a/web/src/lib/stats.ts
+++ b/web/src/lib/stats.ts
@@ -8,6 +8,7 @@ export interface SessionStats {
   maxDrawdown: number;
   winRolls: number;
   lossRolls: number;
+  pushRolls: number;
   noActionRolls: number;
   avgTableLoad: number;
   maxTableLoad: number;
@@ -78,6 +79,8 @@ export function computeSessionStats(result: EngineResult): SessionStats {
   let maxDrawdown = 0;
   let winRolls = 0;
   let lossRolls = 0;
+  let pushRolls = 0;
+  let noActionRolls = 0;
   let totalTableLoad = 0;
   let maxTableLoad = 0;
 
@@ -89,17 +92,22 @@ export function computeSessionStats(result: EngineResult): SessionStats {
     const drawdown = lastPeak - roll.bankrollAfter;
     if (drawdown > maxDrawdown) maxDrawdown = drawdown;
 
+    // Each flag is independent — a roll can count in multiple categories
+    // (e.g. loss + push on a ComeBet seven-out with odds OFF). noAction is strict:
+    // only rolls with zero outcomes of any kind.
     const hasWin = roll.outcomes.some(o => o.result === 'win');
     const hasLoss = roll.outcomes.some(o => o.result === 'loss');
+    const hasPush = roll.outcomes.some(o => o.result === 'push');
     if (hasWin) winRolls++;
     if (hasLoss) lossRolls++;
+    if (hasPush) pushRolls++;
+    if (!hasWin && !hasLoss && !hasPush) noActionRolls++;
 
     totalTableLoad += roll.tableLoadBefore;
     if (roll.tableLoadBefore > maxTableLoad) maxTableLoad = roll.tableLoadBefore;
   }
 
   const totalRolls = rolls.length;
-  const noActionRolls = totalRolls - winRolls - lossRolls;
   const avgTableLoad = totalRolls > 0 ? Math.round((totalTableLoad / totalRolls) * 100) / 100 : 0;
 
   return {
@@ -110,6 +118,7 @@ export function computeSessionStats(result: EngineResult): SessionStats {
     maxDrawdown,
     winRolls,
     lossRolls,
+    pushRolls,
     noActionRolls,
     avgTableLoad,
     maxTableLoad,


### PR DESCRIPTION
## Summary
This PR introduces support for tracking "push" outcomes in craps betting, where certain bets return the player's stake without a win or loss. This includes DontPass/DontCome bar-12 transits and ComeBet odds returned on seven-out when odds are OFF.

## Key Changes

- **Outcome Type Extension**: Updated `Outcome` interface to include `'push'` as a valid result type alongside `'win'` and `'loss'`

- **DontPass Bar-12 Push Handling**: Added logic to detect when a DontPassBet has `payOut === 0` and `amount === 0` (explicitly set, not undefined), treating this as a push outcome where the flat stake is returned intact

- **ComeBet Odds Return on Seven-Out**: When a ComeBet loses on seven-out but had odds OFF (not at risk), the odds amount is now returned as a separate push outcome, distinct from the flat bet loss

- **BetSnapshot Enhancement**: Modified `collectOutcomes()` in both `CrapsEngine` and `SharedTable` to destructure `oddsAmount` from snapshots, enabling proper tracking of returned odds

- **Activity Metrics**: 
  - Added `rollsWithPush` counter to track rolls with push outcomes
  - Updated activity calculation to treat win/loss/push flags as independent (a roll can count in multiple categories)
  - Fixed `rollsNoAction` calculation to only count rolls with zero outcomes of any kind

- **Statistics Updates**:
  - Added `pushRolls` and `pushRate` to `SummaryRecord` and session stats
  - Updated console output and UI components to display push roll statistics
  - Improved documentation of activity metric logic

## Implementation Details

- Push outcomes are recorded with `payout: 0` to indicate no money movement
- The implementation maintains backward compatibility by treating undefined `payOut` as loss (existing behavior)
- Activity metrics now properly handle overlapping outcome categories (e.g., a roll can have both a loss and a push)

https://claude.ai/code/session_015XhUTLtaYNZfbguWeutBBQ