### PR TITLE
Add Windows/PowerShell deployment instructions and package-lock.json note

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -37,6 +37,11 @@ gcloud run deploy craps-api \
   --max-instances 2
 ```
 
+> **Windows/PowerShell**: Backslash line continuation doesn't work. Use a single line:
+> ```powershell
+> gcloud run deploy craps-api --source . --region us-central1 --no-allow-unauthenticated --max-instances 2
+> ```
+
 ## Deploy Both
 ```bash
 cd web && npm run build && cd ..
@@ -48,12 +53,20 @@ gcloud run deploy craps-api \
   --max-instances 2
 ```
 
+> **Windows/PowerShell**: Run each command on a single line — no backslash continuation:
+> ```powershell
+> cd web; npm run build; cd ..
+> firebase deploy --only hosting
+> gcloud run deploy craps-api --source . --region us-central1 --no-allow-unauthenticated --max-instances 2
+> ```
+
 ## Infrastructure Notes
 
 - Firebase Hosting rewrites `/api/**` to Cloud Run (configured in `firebase.json`)
 - Cloud Run is private — only accessible via Firebase Hosting rewrite
 - Billing alert set at $10/month on GCP billing account
 - Cloud Run capped at 2 instances max
+- **`package-lock.json` must be committed** — if it is in `.gitignore`, Cloud Run builds will fail because `npm ci` requires it
 
 ## GCP Resources
 


### PR DESCRIPTION
## Summary
Updated deployment documentation to provide Windows/PowerShell-compatible instructions and clarified an important requirement for Cloud Run builds.

## Key Changes
- Added Windows/PowerShell-specific deployment instructions for the "Deploy API" section, noting that backslash line continuation doesn't work and providing a single-line alternative
- Added Windows/PowerShell-specific instructions for the "Deploy Both" section with semicolon-separated commands instead of backslash continuation
- Added a critical infrastructure note clarifying that `package-lock.json` must be committed to the repository, as Cloud Run builds will fail if it's in `.gitignore` (since `npm ci` requires it)

## Notable Details
These changes improve the developer experience for Windows users who may encounter issues with bash-style line continuation syntax, and prevent a common build failure scenario by explicitly documenting the `package-lock.json` requirement.

https://claude.ai/code/session_01SxWtWWC49HMoET9vwrzvDt