### PR TITLE
Update CATS strategy documentation with Place bet mechanics

### DIFF
--- a/web/src/pages/StrategiesPage.tsx
+++ b/web/src/pages/StrategiesPage.tsx
@@ -7,7 +7,7 @@ export function StrategiesPage() {
       <StrategySection
         name="CATS"
         tagline="Five-stage escalating strategy. Starts conservative and escalates as session profit grows."
-        houseEdge="Accumulator: pass line 1.41% · Molly stages: come bets with odds ~0.5–0.8%"
+        houseEdge="Accumulator: Place 6/8 ~1.52% · Molly stages: come bets with odds ~0.5–0.8%"
         stages={CATS_STAGES}
       >
         <p>
@@ -17,9 +17,10 @@ export function StrategiesPage() {
           escalates only when the session is winning, retreating automatically when it isn't.
         </p>
         <p>
-          The Accumulator stages use flat pass line bets with minimal odds. The Molly stages
-          add come bets and increase odds as profit milestones are reached. Step-down rules
-          mirror step-up thresholds — two consecutive seven-outs at any Molly stage triggers a
+          The Accumulator stages use Place 6 and Place 8 bets — full at $18 each, then
+          regressed to $12 after the first hit. The Molly stages switch to pass line and come
+          bets with increasing odds as profit milestones are reached. Step-down rules mirror
+          step-up thresholds — two consecutive seven-outs at any Molly stage triggers a
           retreat to the prior stage, protecting gains rather than pressing through cold dice.
         </p>
         <p>
@@ -440,11 +441,11 @@ interface StrategySectionProps {
 }
 
 const CATS_STAGES = [
-  { stage: 'Accumulator Full', entry: 'Session start', bets: 'Pass line + 1X odds' },
-  { stage: 'Accumulator Regressed', entry: 'After first point made', bets: 'Pass line + 1X odds, regressed' },
-  { stage: 'Little Molly', entry: '+$70 net', bets: 'Pass line + 1 come + odds' },
-  { stage: 'Three Point Molly Tight', entry: '+$150 net', bets: 'Pass line + 2 come + odds' },
-  { stage: 'Three Point Molly Loose', entry: '+$250 net', bets: 'Pass line + 2 come + max odds' },
+  { stage: 'Accumulator Full', entry: 'Session start', bets: 'Place 6 + Place 8' },
+  { stage: 'Accumulator Regressed', entry: 'After first 6 or 8 hit', bets: 'Place 6 + Place 8 (regressed)' },
+  { stage: 'Little Molly', entry: '+$70 net', bets: 'Pass line + 1 come + 2× odds' },
+  { stage: 'Three Point Molly Tight', entry: '+$150 net', bets: 'Pass line + 2 come + tiered odds' },
+  { stage: 'Three Point Molly Loose', entry: '+$200 net w/ 6 or 8 covered', bets: 'Pass line + 2 come + 5× odds' },
 ];
 
 const BATS_ACCUMULATOR_STAGES = [


### PR DESCRIPTION
## Summary
Updated the CATS (Craps Accumulator and Molly Stages) strategy documentation to reflect a change in the Accumulator phase from pass line bets to Place 6/8 bets, along with corresponding updates to house edge information and stage descriptions.

## Key Changes
- **House edge clarification**: Updated from "pass line 1.41%" to "Place 6/8 ~1.52%" to accurately reflect the Accumulator betting method
- **Accumulator phase mechanics**: Changed from flat pass line bets with odds to Place 6 and Place 8 bets ($18 full, regressed to $12 after first hit)
- **Stage descriptions**: Updated all five CATS stages to reflect the new betting structure:
  - Accumulator Full: Now uses "Place 6 + Place 8" instead of "Pass line + 1X odds"
  - Accumulator Regressed: Updated trigger to "After first 6 or 8 hit" and bets to regressed Place bets
  - Little Molly: Clarified odds as "2× odds"
  - Three Point Molly Tight: Changed to "tiered odds"
  - Three Point Molly Loose: Updated entry threshold to "+$200 net w/ 6 or 8 covered" and odds to "5× odds"
- **Documentation**: Expanded explanation of how Accumulator stages use Place bets with regression strategy, while Molly stages use pass line and come bets

## Implementation Details
The changes maintain the overall escalation structure of the strategy while providing more precise betting mechanics and clearer documentation of the regression rules and profit thresholds.

https://claude.ai/code/session_01FsgAKKyiG4Vgt4tgMbaYGg