### PR TITLE
Replace RunControls with new RunToolbar component

### DIFF
--- a/web/src/components/RunToolbar.tsx
+++ b/web/src/components/RunToolbar.tsx
@@ -1,0 +1,317 @@
+import { useState, useEffect, useRef, type ReactNode, type KeyboardEvent } from 'react';
+import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
+
+interface FormState {
+  strategyA: string;
+  strategyB: string;
+  rolls: string;
+  bankroll: string;
+  seed: string;
+  seeds: string;
+}
+
+interface FormErrors {
+  rolls?: string;
+  bankroll?: string;
+  seed?: string;
+}
+
+interface PillProps {
+  id: string;
+  label: string;
+  displayValue: string;
+  wide?: boolean;
+  locked?: boolean;
+  suffix?: string;
+  hasChev?: boolean;
+  open: boolean;
+  onToggle: (id: string) => void;
+  error?: string;
+  children: ReactNode;
+}
+
+function Pill({ id, label, displayValue, wide, locked, suffix, hasChev = true, open, onToggle, error, children }: PillProps) {
+  return (
+    <div className="pill-wrap">
+      <button
+        type="button"
+        className={'pill' + (locked ? ' pill--locked' : '')}
+        onClick={() => onToggle(id)}
+        aria-expanded={open}
+        aria-haspopup="true"
+      >
+        <div className={`pill__stack${wide ? ' pill__stack--wide' : ' pill__stack--narrow'}`}>
+          <span className="pill__label">{label}</span>
+          <span className="pill__value-row">
+            {suffix && <span className="pill__suffix">{suffix}</span>}
+            <span className="pill__value">{displayValue}</span>
+          </span>
+        </div>
+        {hasChev && <span className="pill__chev">▾</span>}
+      </button>
+      {open && (
+        <div className="pill-popover">
+          {children}
+          {error && <p className="pill-popover__error">{error}</p>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function RunToolbar() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const [strategies, setStrategies] = useState<string[]>(['CATS']);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [openPill, setOpenPill] = useState<string | null>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
+
+  const isDistribution = location.pathname === '/distribution';
+  const isCompare = location.pathname === '/session-compare';
+  const isDistributionCompare = location.pathname === '/distribution-compare';
+  const isStaticPage = location.pathname === '/strategies' || location.pathname === '/guide';
+
+  const [form, setForm] = useState<FormState>(() => {
+    const strategiesParts = searchParams.get('strategies')?.split(',').map(s => s.trim()) ?? [];
+    return {
+      strategyA: searchParams.get('strategy') ?? strategiesParts[0] ?? 'CATS',
+      strategyB: searchParams.get('test') ?? strategiesParts[1] ?? 'ThreePointMolly3X',
+      rolls: searchParams.get('rolls') ?? '500',
+      bankroll: searchParams.get('bankroll') ?? '300',
+      seed: searchParams.get('seed') ?? '',
+      seeds: searchParams.get('seeds') ?? '500',
+    };
+  });
+
+  useEffect(() => {
+    fetch('/api/strategies')
+      .then(res => res.json() as Promise<string[]>)
+      .then(setStrategies)
+      .catch(() => {/* keep default */});
+  }, []);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (toolbarRef.current && !toolbarRef.current.contains(e.target as Node)) {
+        setOpenPill(null);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  function validate(): FormErrors {
+    const errs: FormErrors = {};
+    const rolls = Number(form.rolls);
+    if (!form.rolls || !Number.isInteger(rolls) || rolls <= 0) errs.rolls = 'Must be a positive integer';
+    const bankroll = Number(form.bankroll);
+    if (!form.bankroll || !Number.isInteger(bankroll) || bankroll <= 0) errs.bankroll = 'Must be a positive integer';
+    if (form.seed !== '') {
+      const seed = Number(form.seed);
+      if (!Number.isInteger(seed)) errs.seed = 'Must be an integer';
+    }
+    return errs;
+  }
+
+  function handleRun() {
+    const errs = validate();
+    if (Object.keys(errs).length > 0) {
+      setErrors(errs);
+      if (errs.rolls) setOpenPill('rolls');
+      else if (errs.bankroll) setOpenPill('bankroll');
+      else if (errs.seed) setOpenPill('seed');
+      return;
+    }
+    setErrors({});
+    setOpenPill(null);
+    const base = isStaticPage ? '/session' : location.pathname;
+    const params = new URLSearchParams({
+      rolls: form.rolls,
+      bankroll: form.bankroll,
+      ...(form.seed !== '' ? { seed: form.seed } : {}),
+    });
+    if (isCompare) {
+      params.set('strategies', `${form.strategyA},${form.strategyB}`);
+    } else if (isDistributionCompare) {
+      params.set('strategy', form.strategyA);
+      params.set('test', form.strategyB);
+      params.set('seeds', form.seeds);
+    } else {
+      params.set('strategy', form.strategyA);
+      if (isDistribution) params.set('seeds', form.seeds);
+    }
+    navigate(`${base}?${params.toString()}`);
+  }
+
+  function setField(name: keyof FormState, value: string) {
+    setForm(f => ({ ...f, [name]: value }));
+    if (name in errors) setErrors(e => ({ ...e, [name]: undefined }));
+  }
+
+  function togglePill(id: string) {
+    setOpenPill(prev => (prev === id ? null : id));
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (e.key === 'Escape') { setOpenPill(null); return; }
+    if (e.key === 'Enter' && (e.target as HTMLElement).tagName !== 'SELECT') handleRun();
+  }
+
+  const showComparePills = isCompare || isDistributionCompare;
+  const showSeedsPill = isDistribution || isDistributionCompare;
+
+  return (
+    <div
+      ref={toolbarRef}
+      role="toolbar"
+      aria-label="Run settings"
+      className="runbar"
+      onKeyDown={handleKeyDown}
+    >
+      <div className="runbar__group">
+        {showComparePills ? (
+          <>
+            <Pill
+              id="baseline"
+              label="Baseline"
+              displayValue={form.strategyA}
+              wide
+              open={openPill === 'baseline'}
+              onToggle={togglePill}
+            >
+              <select
+                value={form.strategyA}
+                onChange={e => { setField('strategyA', e.target.value); setOpenPill(null); }}
+                className="pill-popover__select"
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
+              >
+                {strategies.map(s => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </Pill>
+
+            <span className="runbar__vs">vs</span>
+
+            <Pill
+              id="test"
+              label="Test"
+              displayValue={form.strategyB}
+              wide
+              open={openPill === 'test'}
+              onToggle={togglePill}
+            >
+              <select
+                value={form.strategyB}
+                onChange={e => { setField('strategyB', e.target.value); setOpenPill(null); }}
+                className="pill-popover__select"
+                autoFocus
+              >
+                {strategies.map(s => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </Pill>
+          </>
+        ) : (
+          <Pill
+            id="strategy"
+            label="Strategy"
+            displayValue={form.strategyA}
+            wide
+            open={openPill === 'strategy'}
+            onToggle={togglePill}
+          >
+            <select
+              value={form.strategyA}
+              onChange={e => { setField('strategyA', e.target.value); setOpenPill(null); }}
+              className="pill-popover__select"
+              autoFocus
+            >
+              {strategies.map(s => <option key={s} value={s}>{s}</option>)}
+            </select>
+          </Pill>
+        )}
+
+        <Pill
+          id="rolls"
+          label="Rolls"
+          displayValue={form.rolls}
+          open={openPill === 'rolls'}
+          onToggle={togglePill}
+          error={errors.rolls}
+        >
+          <input
+            type="number"
+            value={form.rolls}
+            onChange={e => setField('rolls', e.target.value)}
+            className="pill-popover__input"
+            autoFocus
+          />
+        </Pill>
+
+        <Pill
+          id="bankroll"
+          label="Bankroll"
+          displayValue={form.bankroll}
+          suffix="$"
+          open={openPill === 'bankroll'}
+          onToggle={togglePill}
+          error={errors.bankroll}
+        >
+          <input
+            type="number"
+            value={form.bankroll}
+            onChange={e => setField('bankroll', e.target.value)}
+            className="pill-popover__input"
+            autoFocus
+          />
+        </Pill>
+
+        {showSeedsPill && (
+          <Pill
+            id="seeds"
+            label="Seeds"
+            displayValue={form.seeds}
+            open={openPill === 'seeds'}
+            onToggle={togglePill}
+          >
+            <input
+              type="number"
+              value={form.seeds}
+              onChange={e => setField('seeds', e.target.value)}
+              className="pill-popover__input"
+              autoFocus
+            />
+          </Pill>
+        )}
+
+        <Pill
+          id="seed"
+          label="Seed"
+          displayValue={form.seed || 'random'}
+          locked={!form.seed}
+          hasChev={false}
+          open={openPill === 'seed'}
+          onToggle={togglePill}
+          error={errors.seed}
+        >
+          <input
+            type="number"
+            value={form.seed}
+            onChange={e => setField('seed', e.target.value)}
+            placeholder="random"
+            className="pill-popover__input"
+            autoFocus
+          />
+        </Pill>
+      </div>
+
+      <div className="runbar__spacer" />
+
+      <button type="button" className="run-btn" onClick={handleRun}>
+        <span className="run-btn__glyph">▶</span>
+        <span>Run</span>
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 import { NavLink, useSearchParams } from 'react-router-dom';
-import { RunControls } from './RunControls';
+import { RunToolbar } from './RunToolbar';
 
 interface ShellProps {
   children: ReactNode;
@@ -86,15 +86,12 @@ export function Shell({ children }: ShellProps) {
           ))}
         </nav>
 
-        {/* Run controls */}
         <div className="flex-1" />
-        <div className="border-t border-gray-700">
-          <RunControls />
-        </div>
       </aside>
 
       {/* Main content */}
       <div className="flex flex-col flex-1" style={{ marginLeft: '240px' }}>
+        <RunToolbar />
         <main className="flex-1 overflow-y-auto">
           {children}
         </main>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,1 +1,143 @@
 @import "tailwindcss";
+
+/* ─── Run Toolbar tokens ─── */
+:root {
+  --bg-runbar:       #2a3340;
+  --bg-runbar-deep:  #222a36;
+  --pill-fill:       #3a4555;
+  --pill-fill-hover: #455064;
+  --pill-border:     #4b5668;
+  --accent-ring:     rgba(43,108,255,0.18);
+  --accent-border:   rgba(43,108,255,0.70);
+  --blue:            #2b6cff;
+  --blue-hover:      #1f5be6;
+  --text-strong:     #e7ecf3;
+  --text-mid:        #9aa6b5;
+  --text-dim:        #6c7684;
+  --mono:            ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+/* ─── Run Toolbar ─── */
+.runbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  background: var(--bg-runbar);
+  border-bottom: 1px solid var(--bg-runbar-deep);
+  box-shadow: inset 0 -1px 0 rgba(0,0,0,.25);
+  flex-shrink: 0;
+}
+.runbar__group  { display: flex; align-items: center; gap: 8px; flex-wrap: nowrap; }
+.runbar__spacer { flex: 1; }
+.runbar__vs {
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 11px;
+  padding: 0 2px;
+}
+
+/* ─── Pill ─── */
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  height: 40px;
+  padding: 0 12px;
+  background: var(--pill-fill);
+  border: 1px solid var(--pill-border);
+  border-radius: 6px;
+  font-family: var(--mono);
+  color: var(--text-strong);
+  cursor: pointer;
+  transition: background .12s, border-color .12s, box-shadow .12s;
+}
+.pill:hover,
+.pill:focus-visible {
+  background: var(--pill-fill-hover);
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 3px var(--accent-ring);
+  outline: none;
+}
+.pill__stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  line-height: 1;
+  gap: 3px;
+}
+.pill__stack--narrow { min-width: 52px; }
+.pill__stack--wide   { min-width: 96px; }
+.pill__label {
+  font-size: 9px;
+  color: var(--text-mid);
+  letter-spacing: .6px;
+  text-transform: uppercase;
+}
+.pill__value-row { display: inline-flex; align-items: baseline; gap: 2px; }
+.pill__suffix    { color: var(--text-dim); font-size: 12px; }
+.pill__value     { font-size: 14px; font-weight: 600; color: var(--text-strong); }
+.pill--locked .pill__value { color: var(--text-dim); }
+.pill__chev { color: #8ea7d9; font-size: 10px; margin-left: 2px; }
+
+/* ─── Run button ─── */
+.run-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 40px;
+  padding: 0 18px;
+  background: var(--blue);
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .4px;
+  cursor: pointer;
+  box-shadow: 0 1px 0 rgba(0,0,0,.25), inset 0 1px 0 rgba(255,255,255,.18);
+  transition: background .12s;
+}
+.run-btn:hover { background: var(--blue-hover); }
+.run-btn__glyph { font-size: 10px; }
+
+/* ─── Pill popover ─── */
+.pill-wrap { position: relative; }
+.pill-popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 100;
+  background: #1e2736;
+  border: 1px solid var(--pill-border);
+  border-radius: 6px;
+  padding: 8px;
+  min-width: 160px;
+  width: max-content;
+  box-shadow: 0 8px 24px rgba(0,0,0,.4);
+}
+.pill-popover__select,
+.pill-popover__input {
+  width: 100%;
+  background: var(--pill-fill);
+  color: var(--text-strong);
+  border: 1px solid var(--pill-border);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-family: var(--mono);
+  font-size: 13px;
+  outline: none;
+  box-sizing: border-box;
+}
+.pill-popover__select:focus,
+.pill-popover__input:focus {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+.pill-popover__error {
+  color: #f87171;
+  font-size: 11px;
+  font-family: var(--mono);
+  margin: 4px 0 0;
+}


### PR DESCRIPTION
## Summary
Replaces the existing `RunControls` component with a new `RunToolbar` component that provides an improved UI for configuring and running simulation sessions. The new toolbar features a modern pill-based design with popovers for input controls.

## Key Changes
- **New RunToolbar component** (`web/src/components/RunToolbar.tsx`):
  - Implements a toolbar with pill-shaped controls for strategy selection, rolls, bankroll, seeds, and seed configuration
  - Supports multiple page contexts: single strategy sessions, session comparisons, distribution analysis, and distribution comparisons
  - Includes form validation for numeric inputs (rolls, bankroll, seed)
  - Manages URL search parameters for state persistence
  - Provides keyboard navigation (Escape to close popovers, Enter to run)
  - Implements click-outside detection to close open popovers
  - Displays contextual controls based on current page (e.g., "Baseline vs Test" for comparisons, "Seeds" for distributions)

- **Comprehensive styling** (`web/src/index.css`):
  - Added CSS custom properties for consistent theming (dark color palette)
  - Styled pill buttons with hover states and focus rings
  - Popover styling with dropdown inputs and error messages
  - Run button with blue accent color and shadow effects
  - Responsive layout with flexbox

- **Updated Shell component** (`web/src/components/Shell.tsx`):
  - Removed `RunControls` import and usage
  - Integrated `RunToolbar` as a top-level toolbar in the main content area
  - Removed border styling that was previously applied to run controls

## Notable Implementation Details
- Form state is initialized from URL search parameters, enabling shareable simulation configurations
- Validation errors are displayed inline within popovers and automatically focus the first invalid field
- The toolbar adapts its layout based on the current route (comparison vs. single strategy modes)
- Seed field has special handling: displays "random" when empty and shows a locked state visually
- Keyboard event handling allows Enter to trigger runs and Escape to close popovers

https://claude.ai/code/session_01NsRiJShThFetRLUAkP1dfn