### PR TITLE
Refactor Pill component to support inline editing and dropdown modes

### DIFF
--- a/web/src/components/RunToolbar.tsx
+++ b/web/src/components/RunToolbar.tsx
@@ -24,32 +24,68 @@ interface PillProps {
   locked?: boolean;
   suffix?: string;
   hasChev?: boolean;
+  /** true → dropdown popover; false → inline edit */
+  isDropdown?: boolean;
   open: boolean;
   onToggle: (id: string) => void;
   error?: string;
   children: ReactNode;
 }
 
-function Pill({ id, label, displayValue, wide, locked, suffix, hasChev = true, open, onToggle, error, children }: PillProps) {
+function Pill({
+  id, label, displayValue, wide, locked, suffix,
+  hasChev = true, isDropdown = false, open, onToggle, error, children,
+}: PillProps) {
+  const stackClass = `pill__stack${wide ? ' pill__stack--wide' : ' pill__stack--narrow'}`;
+  const lockedClass = locked ? ' pill--locked' : '';
+
+  // Inline-edit mode: pill becomes a <div> so the nested <input> is valid HTML
+  if (open && !isDropdown) {
+    return (
+      <div className="pill-wrap">
+        <div className={`pill pill--open${lockedClass}`}>
+          <div className={stackClass}>
+            <span className="pill__label">{label}</span>
+            <span className="pill__value-row">
+              {suffix && <span className="pill__suffix">{suffix}</span>}
+              {children}
+            </span>
+          </div>
+          {hasChev && <span className="pill__chev">▾</span>}
+        </div>
+        {error && <p className="pill-inline-error">{error}</p>}
+      </div>
+    );
+  }
+
+  const btnClass = [
+    'pill',
+    lockedClass,
+    open ? ' pill--open' : '',
+    open && isDropdown ? ' pill--dropdown-open' : '',
+  ].join('').trim();
+
   return (
     <div className="pill-wrap">
       <button
         type="button"
-        className={'pill' + (locked ? ' pill--locked' : '')}
+        className={btnClass}
         onClick={() => onToggle(id)}
         aria-expanded={open}
-        aria-haspopup="true"
+        aria-haspopup={isDropdown ? 'listbox' : undefined}
       >
-        <div className={`pill__stack${wide ? ' pill__stack--wide' : ' pill__stack--narrow'}`}>
+        <div className={stackClass}>
           <span className="pill__label">{label}</span>
           <span className="pill__value-row">
             {suffix && <span className="pill__suffix">{suffix}</span>}
             <span className="pill__value">{displayValue}</span>
           </span>
         </div>
-        {hasChev && <span className="pill__chev">▾</span>}
+        {hasChev && (
+          <span className={`pill__chev${open && isDropdown ? ' pill__chev--open' : ''}`}>▾</span>
+        )}
       </button>
-      {open && (
+      {open && isDropdown && (
         <div className="pill-popover">
           {children}
           {error && <p className="pill-popover__error">{error}</p>}
@@ -59,6 +95,17 @@ function Pill({ id, label, displayValue, wide, locked, suffix, hasChev = true, o
   );
 }
 
+// Maps pill IDs to FormState keys (used for revert-on-escape)
+const PILL_TO_FORM_KEY: Partial<Record<string, keyof FormState>> = {
+  strategy: 'strategyA',
+  baseline: 'strategyA',
+  test:     'strategyB',
+  rolls:    'rolls',
+  bankroll: 'bankroll',
+  seed:     'seed',
+  seeds:    'seeds',
+};
+
 export function RunToolbar() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -67,6 +114,7 @@ export function RunToolbar() {
   const [errors, setErrors] = useState<FormErrors>({});
   const [openPill, setOpenPill] = useState<string | null>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
+  const editStartRef = useRef<Record<string, string>>({});
 
   const isDistribution = location.pathname === '/distribution';
   const isCompare = location.pathname === '/session-compare';
@@ -78,10 +126,10 @@ export function RunToolbar() {
     return {
       strategyA: searchParams.get('strategy') ?? strategiesParts[0] ?? 'CATS',
       strategyB: searchParams.get('test') ?? strategiesParts[1] ?? 'ThreePointMolly3X',
-      rolls: searchParams.get('rolls') ?? '500',
-      bankroll: searchParams.get('bankroll') ?? '300',
-      seed: searchParams.get('seed') ?? '',
-      seeds: searchParams.get('seeds') ?? '500',
+      rolls:     searchParams.get('rolls')    ?? '500',
+      bankroll:  searchParams.get('bankroll') ?? '300',
+      seed:      searchParams.get('seed')     ?? '',
+      seeds:     searchParams.get('seeds')    ?? '500',
     };
   });
 
@@ -151,7 +199,24 @@ export function RunToolbar() {
   }
 
   function togglePill(id: string) {
-    setOpenPill(prev => (prev === id ? null : id));
+    setOpenPill(prev => {
+      if (prev !== id) {
+        const key = PILL_TO_FORM_KEY[id];
+        if (key) editStartRef.current[id] = form[key];
+      }
+      return prev === id ? null : id;
+    });
+  }
+
+  function commitInline() {
+    setOpenPill(null);
+  }
+
+  function revertAndClose(id: string) {
+    const key = PILL_TO_FORM_KEY[id];
+    const startVal = editStartRef.current[id];
+    if (key !== undefined && startVal !== undefined) setField(key, startVal);
+    setOpenPill(null);
   }
 
   function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
@@ -161,6 +226,17 @@ export function RunToolbar() {
 
   const showComparePills = isCompare || isDistributionCompare;
   const showSeedsPill = isDistribution || isDistributionCompare;
+
+  // Inline input handlers shared by all number pills
+  function inlineHandlers(id: string) {
+    return {
+      onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter')  { e.preventDefault(); commitInline(); }
+        if (e.key === 'Escape') { e.preventDefault(); revertAndClose(id); }
+      },
+      onBlur: commitInline,
+    };
+  }
 
   return (
     <div
@@ -178,18 +254,23 @@ export function RunToolbar() {
               label="Baseline"
               displayValue={form.strategyA}
               wide
+              isDropdown
               open={openPill === 'baseline'}
               onToggle={togglePill}
             >
-              <select
-                value={form.strategyA}
-                onChange={e => { setField('strategyA', e.target.value); setOpenPill(null); }}
-                className="pill-popover__select"
-                // eslint-disable-next-line jsx-a11y/no-autofocus
-                autoFocus
-              >
-                {strategies.map(s => <option key={s} value={s}>{s}</option>)}
-              </select>
+              <ul className="pill-option-list" role="listbox" aria-label="Baseline strategy">
+                {strategies.map(s => (
+                  <li
+                    key={s}
+                    role="option"
+                    aria-selected={form.strategyA === s}
+                    className={`pill-option${form.strategyA === s ? ' pill-option--active' : ''}`}
+                    onClick={() => { setField('strategyA', s); setOpenPill(null); }}
+                  >
+                    {s}
+                  </li>
+                ))}
+              </ul>
             </Pill>
 
             <span className="runbar__vs">vs</span>
@@ -199,17 +280,23 @@ export function RunToolbar() {
               label="Test"
               displayValue={form.strategyB}
               wide
+              isDropdown
               open={openPill === 'test'}
               onToggle={togglePill}
             >
-              <select
-                value={form.strategyB}
-                onChange={e => { setField('strategyB', e.target.value); setOpenPill(null); }}
-                className="pill-popover__select"
-                autoFocus
-              >
-                {strategies.map(s => <option key={s} value={s}>{s}</option>)}
-              </select>
+              <ul className="pill-option-list" role="listbox" aria-label="Test strategy">
+                {strategies.map(s => (
+                  <li
+                    key={s}
+                    role="option"
+                    aria-selected={form.strategyB === s}
+                    className={`pill-option${form.strategyB === s ? ' pill-option--active' : ''}`}
+                    onClick={() => { setField('strategyB', s); setOpenPill(null); }}
+                  >
+                    {s}
+                  </li>
+                ))}
+              </ul>
             </Pill>
           </>
         ) : (
@@ -218,17 +305,23 @@ export function RunToolbar() {
             label="Strategy"
             displayValue={form.strategyA}
             wide
+            isDropdown
             open={openPill === 'strategy'}
             onToggle={togglePill}
           >
-            <select
-              value={form.strategyA}
-              onChange={e => { setField('strategyA', e.target.value); setOpenPill(null); }}
-              className="pill-popover__select"
-              autoFocus
-            >
-              {strategies.map(s => <option key={s} value={s}>{s}</option>)}
-            </select>
+            <ul className="pill-option-list" role="listbox" aria-label="Strategy">
+              {strategies.map(s => (
+                <li
+                  key={s}
+                  role="option"
+                  aria-selected={form.strategyA === s}
+                  className={`pill-option${form.strategyA === s ? ' pill-option--active' : ''}`}
+                  onClick={() => { setField('strategyA', s); setOpenPill(null); }}
+                >
+                  {s}
+                </li>
+              ))}
+            </ul>
           </Pill>
         )}
 
@@ -244,8 +337,10 @@ export function RunToolbar() {
             type="number"
             value={form.rolls}
             onChange={e => setField('rolls', e.target.value)}
-            className="pill-popover__input"
+            className="pill__inline-input"
+            // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
+            {...inlineHandlers('rolls')}
           />
         </Pill>
 
@@ -262,8 +357,10 @@ export function RunToolbar() {
             type="number"
             value={form.bankroll}
             onChange={e => setField('bankroll', e.target.value)}
-            className="pill-popover__input"
+            className="pill__inline-input"
+            // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
+            {...inlineHandlers('bankroll')}
           />
         </Pill>
 
@@ -279,8 +376,10 @@ export function RunToolbar() {
               type="number"
               value={form.seeds}
               onChange={e => setField('seeds', e.target.value)}
-              className="pill-popover__input"
+              className="pill__inline-input"
+              // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus
+              {...inlineHandlers('seeds')}
             />
           </Pill>
         )}
@@ -300,8 +399,10 @@ export function RunToolbar() {
             value={form.seed}
             onChange={e => setField('seed', e.target.value)}
             placeholder="random"
-            className="pill-popover__input"
+            className="pill__inline-input"
+            // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
+            {...inlineHandlers('seed')}
           />
         </Pill>
       </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -59,6 +59,18 @@
   box-shadow: 0 0 0 3px var(--accent-ring);
   outline: none;
 }
+/* Open state — same blue treatment as hover */
+.pill--open {
+  background: var(--pill-fill-hover);
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 3px var(--accent-ring);
+  outline: none;
+}
+/* Square bottom corners when a dropdown popover is attached */
+.pill--dropdown-open {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
 .pill__stack {
   display: flex;
   flex-direction: column;
@@ -78,7 +90,8 @@
 .pill__suffix    { color: var(--text-dim); font-size: 12px; }
 .pill__value     { font-size: 14px; font-weight: 600; color: var(--text-strong); }
 .pill--locked .pill__value { color: var(--text-dim); }
-.pill__chev { color: #8ea7d9; font-size: 10px; margin-left: 2px; }
+.pill__chev { color: #8ea7d9; font-size: 10px; margin-left: 2px; transition: transform .12s; }
+.pill__chev--open { transform: rotate(180deg); }
 
 /* ─── Run button ─── */
 .run-btn {
@@ -102,42 +115,84 @@
 .run-btn:hover { background: var(--blue-hover); }
 .run-btn__glyph { font-size: 10px; }
 
-/* ─── Pill popover ─── */
+/* ─── Pill popover (strategy dropdown) ─── */
 .pill-wrap { position: relative; }
 .pill-popover {
   position: absolute;
-  top: calc(100% + 4px);
+  top: 100%;           /* flush — no gap */
   left: 0;
   z-index: 100;
   background: #1e2736;
-  border: 1px solid var(--pill-border);
-  border-radius: 6px;
-  padding: 8px;
-  min-width: 160px;
+  border: 1px solid var(--accent-border);
+  border-top: none;    /* merges with pill's bottom border */
+  border-radius: 0 0 6px 6px;
+  padding: 6px;
+  min-width: 100%;
   width: max-content;
-  box-shadow: 0 8px 24px rgba(0,0,0,.4);
-}
-.pill-popover__select,
-.pill-popover__input {
-  width: 100%;
-  background: var(--pill-fill);
-  color: var(--text-strong);
-  border: 1px solid var(--pill-border);
-  border-radius: 4px;
-  padding: 6px 8px;
-  font-family: var(--mono);
-  font-size: 13px;
-  outline: none;
-  box-sizing: border-box;
-}
-.pill-popover__select:focus,
-.pill-popover__input:focus {
-  border-color: var(--accent-border);
-  box-shadow: 0 0 0 2px var(--accent-ring);
+  max-width: 320px;
+  box-shadow: 0 0 0 3px var(--accent-ring), 0 8px 24px rgba(0,0,0,.4);
 }
 .pill-popover__error {
   color: #f87171;
   font-size: 11px;
   font-family: var(--mono);
   margin: 4px 0 0;
+}
+
+/* ─── Strategy option list ─── */
+.pill-option-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 240px;
+  overflow-y: auto;
+}
+.pill-option {
+  padding: 6px 8px;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--text-strong);
+  cursor: pointer;
+  border-radius: 3px;
+  white-space: nowrap;
+  user-select: none;
+}
+.pill-option:hover    { background: var(--pill-fill-hover); }
+.pill-option--active  { color: var(--blue); }
+
+/* ─── Inline number/text input (renders inside the pill) ─── */
+.pill__inline-input {
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-strong);
+  width: 100%;
+  min-width: 0;
+  outline: none;
+  line-height: 1;
+}
+.pill__inline-input::placeholder            { color: var(--text-dim); }
+.pill__inline-input[type=number]            { -moz-appearance: textfield; }
+.pill__inline-input::-webkit-outer-spin-button,
+.pill__inline-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+
+/* Error shown below an inline-edit pill */
+.pill-inline-error {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 101;
+  color: #f87171;
+  font-size: 11px;
+  font-family: var(--mono);
+  white-space: nowrap;
+  background: #1e2736;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid #4b5668;
+  margin: 0;
 }


### PR DESCRIPTION
## Summary
This PR refactors the `Pill` component in RunToolbar to support two distinct interaction modes: inline editing (for numeric inputs) and dropdown popovers (for strategy selection). The changes improve UX by allowing users to edit values directly within pills and revert changes with Escape key, while maintaining separate visual and behavioral patterns for each mode.

## Key Changes

- **Dual-mode Pill component**: Added `isDropdown` prop to distinguish between dropdown popovers (strategy selection) and inline edit mode (numeric inputs)
  - Inline mode renders the pill as a `<div>` with nested `<input>` for valid HTML structure
  - Dropdown mode renders as a `<button>` with a popover menu
  
- **Inline editing with revert-on-escape**: 
  - New `editStartRef` tracks initial values when a pill opens
  - `revertAndClose()` function restores original value on Escape key
  - `commitInline()` function saves changes on Enter or blur
  - Shared `inlineHandlers()` utility provides consistent keyboard/blur behavior

- **Strategy selection UI improvements**:
  - Replaced `<select>` elements with semantic `<ul role="listbox">` for better accessibility
  - Added active state styling for selected options
  - Improved visual feedback with hover states

- **Visual refinements**:
  - Added `.pill--open` state styling (blue background matching hover)
  - Added `.pill--dropdown-open` to square bottom corners when popover is attached
  - Animated chevron rotation (180°) when dropdown opens
  - Inline inputs render transparently within the pill value area
  - Error messages positioned below inline-edit pills vs. inside popovers

- **CSS updates**:
  - New `.pill__inline-input` class for transparent, borderless inputs
  - New `.pill-option-list` and `.pill-option` classes for strategy selection
  - Improved `.pill-popover` styling with flush top border and accent ring
  - Removed spinner buttons from number inputs for cleaner appearance
  - Added `.pill-inline-error` for error display below inline pills

- **Code organization**:
  - Added `PILL_TO_FORM_KEY` mapping for consistent pill-to-form-state lookups
  - Improved class name construction with clearer variable names
  - Better alignment/formatting of form state initialization

https://claude.ai/code/session_01TzKVbC3FfQJsrxMzp9vYde