### PR TITLE
CATS Phase 3: funded entry, unit system, stopping rules, and run architecture

### DIFF
--- a/docs/analytics-guide.md
+++ b/docs/analytics-guide.md
@@ -1,0 +1,176 @@
+# Analytics Guide — I/O Contracts and Evaluator Usage
+
+This guide documents the data contracts between the simulator's producers
+(`run-sim`) and consumers (`analyze-stages`, the stopping-rule evaluator,
+comparison mode, and the server), plus how to use the analysis tools and
+what their limitations are. Schemas here are versioned by the manifest's
+`schemaVersion` (currently **1**).
+
+## 1. JSONL per-roll record (produced by `run-sim --output json`)
+
+One JSON object per line. Three record types; consumers must skip lines
+whose `type` they do not recognize.
+
+```jsonc
+// First line of a run:
+{ "type": "manifest", "manifest": { /* see §4 */ } }
+
+// One per roll:
+{
+  "type": "roll",
+  "roll": { "number": 1, "die1": 3, "die2": 4, "sum": 7 },
+  "gameState": { "pointBefore": null, "pointAfter": null },
+  "players": [{
+    "id": "player1",
+    "strategy": "CATS@entry=littleMolly",       // canonical spec
+    "stageName": "littleMolly",                  // stage AFTER the roll's events settle
+    "stagePlayed": "littleMolly",                // stage whose board PLAYED the roll — use for attribution
+    "bankroll": { "before": 300, "after": 264, "change": -36 },
+    "tableLoad": { "before": 36, "after": 36, "betCount": 2 },
+    "activeBets": [{ "type": "place", "point": 6, "amount": 18, "odds": 0 }],
+    "outcomes": [{ "type": "place", "point": 6, "result": "win", "payout": 39 }]
+  }]
+}
+
+// Last line:
+{ "type": "summary", "meta": { /* strategy, seed, timestamp… */ }, /* bankroll, activity, diceDistribution */ }
+```
+
+The aggregator consumes exactly these fields per roll:
+
+| Field | Used for |
+|---|---|
+| `players[0].stagePlayed` (fallback `stageName`) | per-stage attribution, fall-below-stage rule |
+| `players[0].bankroll.after + tableLoad.after` | **equityAfter** — the per-roll equity trajectory |
+| `players[0].activeBets.length` + `tableLoad.before` | ruin detection (a roll beginning with an empty felt ends a ruined session) |
+
+Notes: `stageName` is captured after post-roll events, so a stage's
+exit-winning roll is credited to the *next* stage under `stageName`;
+`stagePlayed` is the attribution-correct field. `tableLoad.after` is a
+post-settlement snapshot (winning bets already taken down).
+
+## 2. Analyze report (JSON) — `analyze-stages --output json`
+
+```jsonc
+{
+  "sessions": 2000,
+  "rollsPerSession": 300,
+  "bankroll": 300,
+  "totalRolls": 412345,
+  "stages": [{
+    "stage": "littleMolly",
+    "reachProbability": 0.72,          // fraction of sessions that ever enter
+    "medianRollsToFirstEntry": 81,     // among sessions that reach it
+    "p90RollsToFirstEntry": 421,
+    "timeInStagePct": 6.1,             // % of all rolls played on this stage's board
+    "lossPer100Rolls": 7.58,           // per-roll EQUITY change attributed by stagePlayed
+    "rollsObserved": 88933
+  }],
+  "pnl": { "p10": -297, "p50": -289, "p90": 90 },
+  "pctSessionsPositive": 17.9,
+  "pctSessionsRuined": 53.8,
+  "stopping": { /* see §3 */ },
+  "manifest": { /* see §4 */ }
+}
+```
+
+Comparison mode (`--strategy A --strategy B …`) emits an **array** of
+`{ "spec": "<canonical>", "report": <analyze report> }`, one entry per spec,
+all run on the identical seed range (0..seeds−1 — same dice per seed).
+
+## 3. Stopping-rule report — `report.stopping`
+
+Computed in one pass while sessions play fully out. The rules never stop the
+simulation; each banks the equity of the roll on which it fires.
+
+```jsonc
+{
+  "rules": [{
+    "rule": "target-2x",               // none | target-{2,3,6}x | trail | below-stage | cap-{100,200,300}
+    "params": { "k": 2 },              // trail: {drop}; below-stage: {slug}; caps: {rolls}
+    "triggerRate": 0.18,               // fired before session end
+    "ruinRate": 0.15,                  // session ruined before the rule fired
+    "censoredRate": 0.67,              // horizon reached without firing — banked = final P&L
+    "banked": { "p10": -293, "p50": -61, "p90": 319 },
+    "pctPositive": 35.0,
+    "peakCapture": 0.41                // Σ(exit P&L) ÷ Σ(peak P&L) over peak-positive paths
+  }],
+  "hitting": [{ "k": 2, "pHitBeforeRuin": 0.18, "censoredFraction": 0.67 }],
+  "peakPnl": { "p10": 12, "p25": 39, "p50": 77, "p75": 208, "p90": 515, "p99": 1346 }
+}
+```
+
+Rule semantics:
+
+- **none** — never fires; banked = final P&L. Reproduces the session P&L
+  metrics to the dollar (pinned by spec).
+- **target-kx** — fires when equity ≥ k·B; banks the crossing roll's equity.
+- **trail** — fires when equity ≤ running peak − d (d = B/3 default,
+  `--trail-drop` to configure). The starting bankroll seeds the peak, so a
+  straight decline fires at −d (a stop-loss is the degenerate trailing floor).
+- **below-stage** — arms once the session's `stagePlayed` reaches the
+  configured slug's ladder level, fires on the first roll below it
+  (`--exit-below-stage <slug>`; default = the ladder's first gated stage).
+- **cap-N** — fires at roll N; banks that roll's equity.
+
+**Limitations.** *Censoring:* a censored session (horizon reached, rule
+unfired) contributes its final P&L to the rule's banked distribution — for
+slow rules at short horizons the banked numbers are dominated by censoring,
+which is why censoredRate is always reported alongside; hitting
+probabilities state their censored fraction for the same reason.
+*Peak-capture* is a ratio of sums (mean-of-ratios explodes when peaks are
+near zero) and is only over peak-positive paths. *Fall-below-stage* needs a
+ladder: it is omitted for non-staged strategies and for `--jsonl-dir` runs
+without a `--strategy` spec to resolve the ladder against.
+
+**Dual-path validation.** The streaming evaluator (incremental per-roll
+state) is validated against an independent post-hoc implementation that
+truncates archived JSONL trajectories; `scripts/dual-path-check.ts` asserts
+exact equality on 500 seeds, and the spec suite re-runs the equality on
+smaller slices plus hand-built trajectories. If you add a rule, extend both
+implementations and the check.
+
+## 4. Run manifest (embedded in every output mode)
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "strategySpec": "CATS@entry=threePtMollyLoose",  // canonical; "jsonl:<dir>" for re-analysis
+  "tableMin": 10,
+  "bankroll": 300,
+  "rolls": 300,
+  "seeds": { "count": 1000 },                       // or { "seed": 7 } / { "seed": null }
+  "engineVersion": "8f3bee4",                       // git short sha (ENGINE_VERSION fallback)
+  "generatedAt": "2026-08-12T15:38:49.740Z"         // wall-clock; EXCLUDED from identity
+}
+```
+
+Determinism makes the manifest the archive: a run is fully reproducible from
+the identity fields. The server memoizes aggregates keyed by
+`manifestHash(manifest)` — a sha256 of the recursively key-sorted manifest
+minus `generatedAt`. Byte-for-byte comparisons of JSONL across runs must
+normalize `generatedAt` (and the summary line's `timestamp`); everything
+else is deterministic per seed.
+
+## 5. Usage
+
+```bash
+# Single spec, stage metrics + stopping menu:
+npx ts-node src/cli/analyze-stages.ts --strategy CATS --rolls 1000 --bankroll 300 \
+    --seeds 2000 --stop-at-ruin [--trail-drop 100] [--exit-below-stage littleMolly]
+
+# Funded entry and table minimum via canonical specs:
+npx ts-node src/cli/analyze-stages.ts --strategy CATS@entry=threePtMollyLoose,tableMin=15 ...
+
+# Side-by-side comparison on shared seeds (the v4 target workflow):
+npx ts-node src/cli/analyze-stages.ts \
+    --strategy CATS@entry=accumulator --strategy CATS@entry=threePtMollyLoose \
+    --rolls 300 --bankroll 300 --seeds 1000 --stop-at-ruin [--output json]
+
+# Post-hoc re-analysis of archived trajectories:
+npx ts-node src/cli/analyze-stages.ts --jsonl-dir ./sessions [--strategy CATS]  # spec resolves the ladder
+
+# Validation gates:
+scripts/bit-identity-check.sh [ref]        # byte-identical JSONL vs a git ref
+npx ts-node scripts/dual-path-check.ts     # streaming === post-hoc, 500 seeds
+```

--- a/docs/analytics-guide.md
+++ b/docs/analytics-guide.md
@@ -1,19 +1,139 @@
-# Analytics Guide — I/O Contracts and Evaluator Usage
+# Analytics Guide — Stage Metrics, Stopping Rules, and I/O Contracts
 
-This guide documents the data contracts between the simulator's producers
-(`run-sim`) and consumers (`analyze-stages`, the stopping-rule evaluator,
-comparison mode, and the server), plus how to use the analysis tools and
-what their limitations are. Schemas here are versioned by the manifest's
-`schemaVersion` (currently **1**).
+*Documentation for the simulator's analytic layer: `src/cli/analyze-stages.ts` (stage metrics, the stopping-rule menu, multi-spec comparison) and `src/cli/sweep-thresholds.ts`, which sit atop `run-sim.ts` and the stage-machine DSL. Covers the commands, what they output, what each number means, the data contracts between producers and consumers, and — importantly — what these tools can and cannot tell you.*
 
-## 1. JSONL per-roll record (produced by `run-sim --output json`)
+---
 
-One JSON object per line. Three record types; consumers must skip lines
-whose `type` they do not recognize.
+## 1. Overview
+
+The analytic layer answers session-level questions the per-roll simulator can't answer directly: *how often does a strategy reach each stage, how long does it take, where does the time go, what does each stage cost empirically, how do sessions end — and how would they have ended under a disciplined exit rule?* It exists because a staged strategy's document-level math (per-bet edges, per-roll costs) says nothing about path-dependent properties — stage-reach probability, grind time, ruin rates, peak capture — which turn out to drive both the player experience and the design decisions.
+
+| Tool | Question it answers |
+|---|---|
+| `analyze-stages` | Per-stage and per-session metrics for one strategy spec; the stopping-rule menu; side-by-side comparison of multiple specs on shared dice |
+| `sweep-thresholds` | How the metrics respond to moving the CATS Stage 1→2 profit gate |
+
+Both are strategy-aware but not CATS-specific: `analyze-stages` works for any registered staged strategy (the stage display ordering knows both the CATS ladder and the BATS/Dolly stages; unrecognized stages append in encounter order), and funded entry, spec parsing, and the fall-below-stage rule all resolve through each strategy's own exported stage metadata.
+
+Every output mode embeds a versioned **run manifest** (§8): determinism makes the manifest the archive — a run is fully reproducible from a few hundred bytes, which is also how the server memoizes aggregates.
+
+## 2. analyze-stages — running it
+
+Three modes. **Internal mode** runs sessions itself:
+
+```
+npx ts-node src/cli/analyze-stages.ts --strategy CATS --rolls 300 \
+    --bankroll 300 --seeds 2000 --stop-at-ruin --output text
+```
+
+**Comparison mode** repeats `--strategy`; every spec runs on the identical seed range (same dice per seed), and output renders side-by-side (this is the v4 target workflow):
+
+```
+npx ts-node src/cli/analyze-stages.ts \
+    --strategy CATS@entry=accumulator --strategy CATS@entry=threePtMollyLoose \
+    --rolls 300 --bankroll 300 --seeds 1000 --stop-at-ruin
+```
+
+**JSONL mode** consumes a directory of per-session files previously produced by `run-sim.ts --output json`:
+
+```
+npx ts-node src/cli/analyze-stages.ts --jsonl-dir ./sessions [--strategy CATS] --output json
+```
+
+| Flag | Meaning | Default |
+|---|---|---|
+| `--strategy <spec>` | Strategy spec `NAME[@key=value,...]` — keys `entry` (funded-entry stage slug) and `tableMin`. Repeatable for comparison mode. | — (this or `--jsonl-dir` required) |
+| `--jsonl-dir <path>` | Directory of run-sim JSONL session files (add `--strategy` to resolve the ladder for the fall-below-stage rule) | — |
+| `--rolls <n>` | Roll cap per session | 1000 |
+| `--bankroll <n>` | Buy-in per session | 300 |
+| `--seeds <n>` | Number of sessions; seeds run 0..n−1 deterministically | 2000 |
+| `--stop-at-ruin` | End a session when it can no longer fund its bets | off |
+| `--trail-drop <n>` | Trailing-floor stopping rule's drop d, in dollars | bankroll ÷ 3 |
+| `--exit-below-stage <slug>` | Fall-below-stage stopping rule's slug | ladder's first gated stage |
+| `--output text\|json` | Human table or machine-readable report | text |
+
+There is also a programmatic API: `analyzeWithFactory(...)`, `runComparison(...)`, and the stopping evaluator are exported; `sweep-thresholds` reuses the aggregation this way.
+
+## 3. What it outputs
+
+**Per stage:**
+
+| Field | Definition |
+|---|---|
+| Reach % | Fraction of sessions that *ever* enter the stage |
+| Med / P90 entry | Median and p90 rolls to first entry — computed **among sessions that reach the stage** (see limitations) |
+| Time % | Share of all simulated rolls attributed to the stage |
+| E[loss]/100 | Empirical expected loss per 100 rolls while in the stage (see methodology; see limitations before quoting this for rarely-occupied stages) |
+
+**Per session set:** P&L p10/p50/p90, % of sessions ending positive, % ending at ruin.
+
+**Stopping-rule menu:** per rule, trigger/ruin/censored rates, banked P&L percentiles, % positive, peak-capture ratio; plus hitting probabilities P(k·B before ruin) and the peak-P&L distribution (§5).
+
+Comparison mode renders columns = specs, rows = the above; JSON mode emits an array of `{ "spec": "<canonical>", "report": ... }`.
+
+## 4. Methodology — how the numbers are computed
+
+**Equity accounting.** Loss is measured as the per-roll change in *equity* — rack plus money on the felt — after each roll's payouts settle. Moving money onto the table is therefore not counted as loss, and the session P&L definition matches the strategy document's §3.7 profit accounting exactly. This is the correct convention for a staged strategy, where stepping up moves large sums from rack to felt without losing anything.
+
+**Stage attribution.** Each roll is attributed to `stagePlayed` — the stage whose `board()` built the bets that actually rode that roll — falling back to `stageName` for older JSONL without the field. This matters at transitions: the roll where a stage change is *decided* is charged to the stage whose bets were at risk, not the incoming stage.
+
+**Determinism.** Internal mode runs seeds 0..N−1. Repeat runs with the same flags reproduce exactly; two configurations run at the same `--seeds` share dice sequences, so differences between them reflect the configuration, not luck. (The manifest's `generatedAt` and the summary line's `timestamp` are the only wall-clock fields — normalize them for byte comparisons.)
+
+**Ruin.** With `--stop-at-ruin`, a session ends when the strategy cannot fund its desired board; the session is flagged ruined and its rolls stop accruing. Without the flag, sessions run to the roll cap regardless. For any question about *session outcomes*, use the flag — a "session" that keeps rolling after it cannot bet is a simulation artifact, not a session.
+
+**Funded entry.** A spec like `CATS@entry=threePtMollyLoose` starts sessions in that stage with `origin = bankroll − gate(entry)`, so profit begins exactly at the stage's entry gate. The seven-out counter starts at zero for every entry. Any bankroll runs, including one below the entry gate (negative origin) — that is a documented experimental configuration, not an error.
+
+## 5. The stopping-rule menu
+
+Computed in one pass while sessions play fully out — the rules never stop the simulation; each banks the equity of the roll on which it fires, and the session continues for the remaining rules and the played-fully-out baseline.
+
+Rule semantics:
+
+- **none** — never fires; banked = final P&L. Reproduces the session P&L metrics to the dollar (pinned by spec).
+- **target-kx** (k ∈ {2, 3, 6}) — fires when equity ≥ k·B; banks the crossing roll's equity.
+- **trail** — fires when equity ≤ running peak − d (d = B/3 default, `--trail-drop` to configure). The starting bankroll seeds the peak, so a straight decline fires at −d (a stop-loss is the degenerate trailing floor).
+- **below-stage** — arms once the session's `stagePlayed` reaches the configured slug's ladder level, fires on the first roll below it (`--exit-below-stage <slug>`; default = the ladder's first gated stage).
+- **cap-N** (N ∈ {100, 200, 300}) — fires at roll N; banks that roll's equity.
+
+Per-rule outcomes are three-way: **triggered** (banked = exit equity − B), **ruin** (session ruined before the rule fired; banked = final P&L), **censored** (horizon reached without firing; banked = final P&L). Alongside the rules, the report carries **hitting probabilities** — P(equity reached k·B before ruin), with the censored fraction stated — and the **peak-P&L distribution** (p10/p25/p50/p75/p90/p99) as a first-class output.
+
+**Dual-path validation.** The streaming evaluator (incremental per-roll state) is validated against an independent post-hoc implementation that truncates archived JSONL trajectories; `scripts/dual-path-check.ts` asserts exact equality on 500 seeds, and the spec suite re-runs the equality on smaller slices plus hand-built trajectories. If you add a rule, extend both implementations and the check.
+
+## 6. sweep-thresholds
+
+```
+npx ts-node src/cli/sweep-thresholds.ts --gates 40,55,70,85,100 \
+    --rolls 1000 --bankroll 300 --seeds 2000
+```
+
+For each gate value, `CATS({ stage2Gate })` scales all higher ladder gates proportionally (`gate/70`, rounded to the dollar). Reports per gate: Stage-2 reach %, median rolls to Stage 2, session P&L p10/p50/p90, % positive, and ruin rate. Seeds are shared across gate values — column differences reflect the gate, not the dice. Defaults: gates `40,55,70,85,100`, 1000 rolls, $300, 2000 seeds, text output.
+
+The committed baseline run lives in `docs/cats-threshold-sensitivity.md`. Its headline: the gate is not an EV knob; it trades *participation* (how often and how soon sessions reach the Molly stages) against *capitalization quality* once there, while the left tail stays pinned by sessions that never escape the Accumulator over long horizons. (The baseline table predates the hard-reset retirement; descent is now handled entirely by the chained retreat floors, which land in the same place — rerun the sweep before quoting its numbers against current code.)
+
+## 7. What the metrics are for
+
+| Question | Metric to use |
+|---|---|
+| "Does the engine match the strategy doc's math?" | E[loss]/100 for *well-occupied* stages vs. the theoretical values in `cats-strategy.md` §1.4 |
+| "How much of a session is grind vs. Alpha play?" | Time % by stage — the session-experience metric |
+| "How often does the ladder actually get climbed?" | Reach % per stage |
+| "How long until the fun starts?" | Median entry to Little Molly (and beyond) |
+| "What do sessions look like when they end?" | P&L percentiles, % positive, ruin rate — **always quoted with their roll cap and bankroll** |
+| "When should a session walk?" | The stopping menu — trigger vs. censored rates, banked P&L, peak capture — as *analysis of exits*, not an in-strategy rule |
+| "Is funded entry worth it?" | Comparison mode on shared seeds: classic vs. `@entry=` specs |
+| "Should a threshold move?" | The sweep — as *input* to a design decision, never as an automatic answer |
+
+## 8. I/O contracts
+
+Schemas are versioned by the manifest's `schemaVersion` (currently **1**).
+
+### 8.1 JSONL per-roll record (produced by `run-sim --output json`)
+
+One JSON object per line. Three record types; consumers must skip lines whose `type` they do not recognize.
 
 ```jsonc
 // First line of a run:
-{ "type": "manifest", "manifest": { /* see §4 */ } }
+{ "type": "manifest", "manifest": { /* see §8.4 */ } }
 
 // One per roll:
 {
@@ -44,12 +164,9 @@ The aggregator consumes exactly these fields per roll:
 | `players[0].bankroll.after + tableLoad.after` | **equityAfter** — the per-roll equity trajectory |
 | `players[0].activeBets.length` + `tableLoad.before` | ruin detection (a roll beginning with an empty felt ends a ruined session) |
 
-Notes: `stageName` is captured after post-roll events, so a stage's
-exit-winning roll is credited to the *next* stage under `stageName`;
-`stagePlayed` is the attribution-correct field. `tableLoad.after` is a
-post-settlement snapshot (winning bets already taken down).
+Notes: `stageName` is captured after post-roll events, so a stage's exit-winning roll is credited to the *next* stage under `stageName`; `stagePlayed` is the attribution-correct field. `tableLoad.after` is a post-settlement snapshot (winning bets already taken down).
 
-## 2. Analyze report (JSON) — `analyze-stages --output json`
+### 8.2 Analyze report (JSON) — `analyze-stages --output json`
 
 ```jsonc
 {
@@ -69,19 +186,14 @@ post-settlement snapshot (winning bets already taken down).
   "pnl": { "p10": -297, "p50": -289, "p90": 90 },
   "pctSessionsPositive": 17.9,
   "pctSessionsRuined": 53.8,
-  "stopping": { /* see §3 */ },
-  "manifest": { /* see §4 */ }
+  "stopping": { /* see §8.3 */ },
+  "manifest": { /* see §8.4 */ }
 }
 ```
 
-Comparison mode (`--strategy A --strategy B …`) emits an **array** of
-`{ "spec": "<canonical>", "report": <analyze report> }`, one entry per spec,
-all run on the identical seed range (0..seeds−1 — same dice per seed).
+Comparison mode emits an **array** of `{ "spec": "<canonical>", "report": <analyze report> }`, one entry per spec.
 
-## 3. Stopping-rule report — `report.stopping`
-
-Computed in one pass while sessions play fully out. The rules never stop the
-simulation; each banks the equity of the roll on which it fires.
+### 8.3 Stopping-rule report — `report.stopping`
 
 ```jsonc
 {
@@ -100,37 +212,7 @@ simulation; each banks the equity of the roll on which it fires.
 }
 ```
 
-Rule semantics:
-
-- **none** — never fires; banked = final P&L. Reproduces the session P&L
-  metrics to the dollar (pinned by spec).
-- **target-kx** — fires when equity ≥ k·B; banks the crossing roll's equity.
-- **trail** — fires when equity ≤ running peak − d (d = B/3 default,
-  `--trail-drop` to configure). The starting bankroll seeds the peak, so a
-  straight decline fires at −d (a stop-loss is the degenerate trailing floor).
-- **below-stage** — arms once the session's `stagePlayed` reaches the
-  configured slug's ladder level, fires on the first roll below it
-  (`--exit-below-stage <slug>`; default = the ladder's first gated stage).
-- **cap-N** — fires at roll N; banks that roll's equity.
-
-**Limitations.** *Censoring:* a censored session (horizon reached, rule
-unfired) contributes its final P&L to the rule's banked distribution — for
-slow rules at short horizons the banked numbers are dominated by censoring,
-which is why censoredRate is always reported alongside; hitting
-probabilities state their censored fraction for the same reason.
-*Peak-capture* is a ratio of sums (mean-of-ratios explodes when peaks are
-near zero) and is only over peak-positive paths. *Fall-below-stage* needs a
-ladder: it is omitted for non-staged strategies and for `--jsonl-dir` runs
-without a `--strategy` spec to resolve the ladder against.
-
-**Dual-path validation.** The streaming evaluator (incremental per-roll
-state) is validated against an independent post-hoc implementation that
-truncates archived JSONL trajectories; `scripts/dual-path-check.ts` asserts
-exact equality on 500 seeds, and the spec suite re-runs the equality on
-smaller slices plus hand-built trajectories. If you add a rule, extend both
-implementations and the check.
-
-## 4. Run manifest (embedded in every output mode)
+### 8.4 Run manifest (embedded in every output mode)
 
 ```jsonc
 {
@@ -145,138 +227,26 @@ implementations and the check.
 }
 ```
 
-Determinism makes the manifest the archive: a run is fully reproducible from
-the identity fields. The server memoizes aggregates keyed by
-`manifestHash(manifest)` — a sha256 of the recursively key-sorted manifest
-minus `generatedAt`. Byte-for-byte comparisons of JSONL across runs must
-normalize `generatedAt` (and the summary line's `timestamp`); everything
-else is deterministic per seed.
+Determinism makes the manifest the archive: a run is fully reproducible from the identity fields. The server memoizes aggregates keyed by `manifestHash(manifest)` — a sha256 of the recursively key-sorted manifest minus `generatedAt`. The server never persists trajectories; JSONL archives are a local/CLI workflow for retroactive rule analysis.
 
-## 5. Usage
-
-```bash
-# Single spec, stage metrics + stopping menu:
-npx ts-node src/cli/analyze-stages.ts --strategy CATS --rolls 1000 --bankroll 300 \
-    --seeds 2000 --stop-at-ruin [--trail-drop 100] [--exit-below-stage littleMolly]
-
-# Funded entry and table minimum via canonical specs:
-npx ts-node src/cli/analyze-stages.ts --strategy CATS@entry=threePtMollyLoose,tableMin=15 ...
-
-# Side-by-side comparison on shared seeds (the v4 target workflow):
-npx ts-node src/cli/analyze-stages.ts \
-    --strategy CATS@entry=accumulator --strategy CATS@entry=threePtMollyLoose \
-    --rolls 300 --bankroll 300 --seeds 1000 --stop-at-ruin [--output json]
-
-# Post-hoc re-analysis of archived trajectories:
-npx ts-node src/cli/analyze-stages.ts --jsonl-dir ./sessions [--strategy CATS]  # spec resolves the ladder
-
-# Validation gates:
-scripts/bit-identity-check.sh [ref]        # byte-identical JSONL vs a git ref
-npx ts-node scripts/dual-path-check.ts     # streaming === post-hoc, 500 seeds
-```
-
-# Analytics Guide — Stage Metrics and Threshold Sweeps
-
-*Documentation for the simulator's analytic layer: `src/cli/analyze-stages.ts` and `src/cli/sweep-thresholds.ts`, which sit atop `run-sim.ts` and the stage-machine DSL. Covers the commands, what they output, what each number means, and — importantly — what these tools can and cannot tell you.*
-
----
-
-## 1. Overview
-
-The analytic layer answers session-level questions the per-roll simulator can't answer directly: *how often does a strategy reach each stage, how long does it take, where does the time go, what does each stage cost empirically, and how do sessions end?* It exists because a staged strategy's document-level math (per-bet edges, per-roll costs) says nothing about path-dependent properties — stage-reach probability, grind time, ruin rates — which turn out to drive both the player experience and the design decisions.
-
-Two tools:
-
-| Tool | Question it answers |
-|---|---|
-| `analyze-stages` | Per-stage and per-session metrics for one strategy at one configuration |
-| `sweep-thresholds` | How those metrics respond to moving the CATS Stage 1→2 profit gate |
-
-Both are strategy-aware but not CATS-specific: `analyze-stages` works for any registered staged strategy (the stage display ordering knows both the CATS ladder and the BATS/Dolly stages; unrecognized stages append in encounter order).
-
-## 2. analyze-stages
-
-### Running it
-
-Two modes. **Internal mode** runs sessions itself:
-
-```
-npx ts-node src/cli/analyze-stages.ts --strategy CATS --rolls 300 \
-    --bankroll 300 --seeds 2000 --stop-at-ruin --output text
-```
-
-**JSONL mode** consumes a directory of per-session files previously produced by `run-sim.ts --output json`:
-
-```
-npx ts-node src/cli/analyze-stages.ts --jsonl-dir ./sessions --output json
-```
-
-| Flag | Meaning | Default |
-|---|---|---|
-| `--strategy <name>` | Registered strategy to simulate (internal mode) | — (this or `--jsonl-dir` required) |
-| `--jsonl-dir <path>` | Directory of run-sim JSONL session files (JSONL mode) | — |
-| `--rolls <n>` | Roll cap per session | 1000 |
-| `--bankroll <n>` | Buy-in per session | 300 |
-| `--seeds <n>` | Number of sessions; seeds run 0..n−1 deterministically | 2000 |
-| `--stop-at-ruin` | End a session when it can no longer fund its bets | off |
-| `--output text\|json` | Human table or machine-readable report | text |
-
-There is also a programmatic API: `analyzeWithFactory(...)` is exported and is how `sweep-thresholds` reuses the aggregation.
-
-### What it outputs
-
-**Per stage:**
-
-| Field | Definition |
-|---|---|
-| Reach % | Fraction of sessions that *ever* enter the stage |
-| Med / P90 entry | Median and p90 rolls to first entry — computed **among sessions that reach the stage** (see limitations) |
-| Time % | Share of all simulated rolls attributed to the stage |
-| E[loss]/100 | Empirical expected loss per 100 rolls while in the stage (see methodology; see limitations before quoting this for rarely-occupied stages) |
-
-**Per session set:** P&L p10/p50/p90, % of sessions ending positive, % ending at ruin.
-
-## 3. Methodology — how the numbers are computed
-
-**Equity accounting.** Loss is measured as the per-roll change in *equity* — rack plus money on the felt — after each roll's payouts settle. Moving money onto the table is therefore not counted as loss, and the session P&L definition matches the strategy document's §3.7 profit accounting exactly. This is the correct convention for a staged strategy, where stepping up moves large sums from rack to felt without losing anything.
-
-**Stage attribution.** Each roll is attributed to `stagePlayed` — the stage whose `board()` built the bets that actually rode that roll — falling back to `stageName` for older JSONL without the field. This matters at transitions: the roll where a stage change is *decided* is charged to the stage whose bets were at risk, not the incoming stage.
-
-**Determinism.** Internal mode runs seeds 0..N−1. Repeat runs with the same flags reproduce exactly; two configurations run at the same `--seeds` share dice sequences, so differences between them reflect the configuration, not luck.
-
-**Ruin.** With `--stop-at-ruin`, a session ends when the strategy cannot fund its desired board; the session is flagged ruined and its rolls stop accruing. Without the flag, sessions run to the roll cap regardless. For any question about *session outcomes*, use the flag — a "session" that keeps rolling after it cannot bet is a simulation artifact, not a session.
-
-## 4. sweep-thresholds
-
-```
-npx ts-node src/cli/sweep-thresholds.ts --gates 40,55,70,85,100 \
-    --rolls 1000 --bankroll 300 --seeds 2000
-```
-
-For each gate value, `CATS({ stage2Gate })` scales all higher ladder gates proportionally (`gate/70`, rounded to the dollar); the §3.4 hard-reset floor stays fixed at $20. Reports per gate: Stage-2 reach %, median rolls to Stage 2, session P&L p10/p50/p90, % positive, and ruin rate. Seeds are shared across gate values — column differences reflect the gate, not the dice. Defaults: gates `40,55,70,85,100`, 1000 rolls, $300, 2000 seeds, text output.
-
-The committed baseline run lives in `docs/cats-threshold-sensitivity.md`. Its headline: the gate is not an EV knob; it trades *participation* (how often and how soon sessions reach the Molly stages) against *capitalization quality* once there, while the left tail stays pinned by sessions that never escape the Accumulator over long horizons.
-
-## 5. What the metrics are for
-
-| Question | Metric to use |
-|---|---|
-| "Does the engine match the strategy doc's math?" | E[loss]/100 for *well-occupied* stages vs. the theoretical values in `cats-strategy.md` §1.4 |
-| "How much of a session is grind vs. Alpha play?" | Time % by stage — the session-experience metric |
-| "How often does the ladder actually get climbed?" | Reach % per stage |
-| "How long until the fun starts?" | Median entry to Little Molly (and beyond) |
-| "What do sessions look like when they end?" | P&L percentiles, % positive, ruin rate — **always quoted with their roll cap and bankroll** |
-| "Should a threshold move?" | The sweep — as *input* to a design decision, never as an automatic answer |
-
-## 6. Limitations — read before quoting numbers
+## 9. Limitations — read before quoting numbers
 
 1. **Selection bias in per-stage E[loss] for rarely-occupied stages.** You only occupy high stages while winning, so their empirical cost is measured on lucky rolls. A stage holding <2–3% of total rolls can show absurd values (a negative "loss," i.e., apparent profit, of −$137/100 has been observed for `threePtMollyLoose` at 0.6% occupancy). For such stages, the theoretical figures in the strategy doc are the truth; the empirical column validates only well-occupied stages. Check `Time %` before believing `E[loss]/100`.
-2. **Horizon sensitivity.** The strategy has no exit rules, so ruin is the only absorbing state and every outcome metric worsens monotonically with the roll cap (observed: 12.8% ruin at 300 rolls vs 53.8% at 1000 for CATS/$300). No P&L or ruin number is meaningful without its `--rolls` and `--bankroll` attached. Never compare runs across different caps.
-3. **Censoring at the roll cap.** Sessions truncate at `--rolls`; entry-time p90s near the cap are censored (the true p90 may be "never within a session"), and reach % is reach-within-cap, not reach-ever.
+2. **Horizon sensitivity.** The strategy has no in-strategy exit rules, so ruin is the only absorbing state and every outcome metric worsens monotonically with the roll cap (observed: 12.8% ruin at 300 rolls vs 53.8% at 1000 for CATS/$300). No P&L or ruin number is meaningful without its `--rolls` and `--bankroll` attached. Never compare runs across different caps. (The stopping menu *analyzes* exits; it does not add them to the strategy.)
+3. **Censoring — everywhere the horizon bites.** Sessions truncate at `--rolls`: entry-time p90s near the cap are censored (the true p90 may be "never within a session"), reach % is reach-within-cap, and a censored session contributes its final P&L to every unfired stopping rule's banked distribution — for slow rules at short horizons the banked numbers are dominated by censoring. That is why `censoredRate` sits beside every rule and hitting probabilities state their censored fraction.
 4. **Survivorship in entry times.** Median/p90 rolls-to-entry are computed among sessions that reached the stage. "Median 122 rolls to Loose Molly" describes the 27% of sessions that got there, not a typical session.
-5. **Model boundary.** The engine implements the strategy document's conventions (place/buy off on come-out, buy vig 5% of bet charged on win). It does not model: comps, tips, dealer pace variation, table changes mid-session, other players' effect on pace, or discretionary off-book bets. Simulated "hours" are rolls ÷ ~100/hr, a convention, not a measurement.
-6. **Deterministic seeds cut both ways.** Reproducibility is exact, but a specific seed set is one draw of 2000 sessions; percentile estimates carry sampling error of roughly ±1–2 points at that N. Rerun at a different seed offset (or larger N) before treating a 1-point difference as real.
+5. **Peak-capture is a ratio of sums** (Σ exit ÷ Σ peak over peak-positive paths) — mean-of-ratios explodes when peaks are near zero. It is not defined when no session peaked positive.
+6. **Fall-below-stage needs a ladder.** The rule is omitted for non-staged strategies and for `--jsonl-dir` runs without a `--strategy` spec to resolve the ladder against.
+7. **Model boundary.** The engine implements the strategy document's conventions (place/buy off on come-out, buy vig 5% of bet charged on win). It does not model: comps, tips, dealer pace variation, table changes mid-session, other players' effect on pace, or discretionary off-book bets. Simulated "hours" are rolls ÷ ~100/hr, a convention, not a measurement.
+8. **Deterministic seeds cut both ways.** Reproducibility is exact, but a specific seed set is one draw of 2000 sessions; percentile estimates carry sampling error of roughly ±1–2 points at that N. Rerun at a different seed offset (or larger N) before treating a 1-point difference as real.
 
-## 7. Reproducing the committed results
+## 10. Reproducing the committed results
 
-The strategy document's §4.1 figures: `analyze-stages --strategy CATS --rolls 1000 --bankroll 300 --seeds 2000 --stop-at-ruin`. The realistic-session comparison quoted in review discussions: same with `--rolls 300`. The threshold sensitivity table: the exact command at the top of `docs/cats-threshold-sensitivity.md`. All are deterministic and should reproduce to the dollar.
+The strategy document's §4.1 figures: `analyze-stages --strategy CATS --rolls 1000 --bankroll 300 --seeds 2000 --stop-at-ruin`. The realistic-session comparison quoted in review discussions: same with `--rolls 300`. The funded-entry teaser in PR #103: the comparison-mode command in §2 at 1000 seeds. The threshold sensitivity table: the exact command at the top of `docs/cats-threshold-sensitivity.md`. All are deterministic and should reproduce to the dollar.
+
+Validation gates, runnable anytime:
+
+```bash
+scripts/bit-identity-check.sh [ref]        # byte-identical JSONL vs a git ref (timestamp-normalized)
+npx ts-node scripts/dual-path-check.ts     # streaming === post-hoc stopping menu, 500 seeds
+```

--- a/docs/reqs/session-lifecycle.md
+++ b/docs/reqs/session-lifecycle.md
@@ -1,6 +1,22 @@
 # Design Note — Funded Entry, Units, and Run Architecture (v4)
 
-*Status: decisions recorded; two items pending review (§4 units, §5 storage). Supersedes v3. On approval of §4–5, this note converts to a Claude Code work order.*
+*Status: **approved and implemented.** The §4 (units) and §5 (storage) review items were approved and the full §6 scope shipped in Phase 3 (branch `claude/cats-phase-2-simulator-ea6qnf`). Supersedes v3.*
+
+**Implementation record (Phase 3 commits):**
+
+| §6 scope item | Commit |
+|---|---|
+| 3. Unit-system module (`src/dsl/units.ts`), literals replaced, $10/$15 no-change proof | `7522b7e` |
+| 1a. Stage-machine `entryStage` + origin-based profit (bit-identity gate passed, seeds 0–99) | `e9607b5` |
+| 1b. Hard-reset retirement (decision #3; no-dead-zone spec) | `e9dd168` |
+| 2. Registry parameterization, `@entry=` canonical specs, stage metadata export | `27afcf3` |
+| 7. BATS acceptance: `BATS@entry=threePtDolly`, zero BATS-specific code | `c123649` |
+| 4. Streaming stopping-menu evaluator (dual-path gate passed, 500 seeds) | `36a7a09` |
+| 5. Multi-spec comparison on shared seeds (target workflow verbatim) | `ff3f521` |
+| 6. Versioned manifest in all outputs; server memoization by manifest hash | `8f3bee4` |
+| 8. Doc sync (`analytics-guide.md` I/O contracts, `cats-strategy.md` unit table + hard-reset note) | this commit |
+
+*Interpretation note recorded at implementation:* the entry-gate ladder gives `threePtMollyLoose` gate 25u (shared with `expandedAlpha`), per the work order's pinned example — a Loose entry at exactly its gate plays one roll on the Loose board and immediately qualifies the ≥25u advance (decision #1: no guard rails; the physics handles it).
 
 ---
 
@@ -12,8 +28,8 @@
 | 2 | Seven-out counter at funded entry | Starts at zero; identical semantics across entry configs. Flagged as an observation target in first funded-entry runs |
 | 3 | Hard-reset rule (§3.4) | **Retired on implementation** — redundant with Accumulator-band entry |
 | 4 | Turbo | Out of main CATS; not currently implemented in the engine (Stage 1b was never built). Future paired experiment parked: "Turbo-Accumulator-only vs Accumulator-only" |
-| 5 | Min-ratio units | Proposal in §4 — **pending review** |
-| 6 | Output storage | Architecture in §5 — **pending review** |
+| 5 | Min-ratio units | Proposal in §4 — **approved; implemented** (`7522b7e`) |
+| 6 | Output storage | Architecture in §5 — **approved; implemented** (`8f3bee4`; Firestore cache left as TODO — not among existing deps) |
 | 7 | BATS | Same mechanism, zero BATS-specific code — the generality test (§2) |
 
 ## 2. Generalized arbitrary stage entry
@@ -37,7 +53,7 @@
 
 Exit rules are stopping times (v3), which enables a stronger form: **evaluate the whole standard menu in one pass during simulation.** Each rule tracks its trigger state per roll; when it fires, its banked P&L is recorded and the session continues playing out for the remaining rules and the played-fully-out baseline. No trajectory persistence is required for the standard menu {none, hard targets kB, trailing floor, fall-below-stage, roll cap}. Trajectory archival is needed only to evaluate *newly invented* rules against *old* runs — a local/CLI workflow, not a serving-path one. Censoring reporting per v3 stands.
 
-## 4. Unit system (REVIEW ITEM)
+## 4. Unit system (APPROVED — implemented in `7522b7e`)
 
 **u = table minimum** for line bets, gates, and risk; **p = smallest proper place bet ≥ u** (7:6 quantization to $6 increments) for place bets, with explicit rounding instead of implicit fudging.
 
@@ -57,7 +73,7 @@ Exit rules are stopping times (v3), which enables a stronger form: **evaluate th
 
 Verification: reproduces every v1.2 hand-scaled $10/$15 figure — a formalization, not a change. **Operational-ease note (recorded, not yet optimized for):** unit phrasing is more memorable than dollars — "gates at seven, fifteen, twenty-five, forty minimums; buys are two minimums; flats are one" — and future rule-writing should prefer unit-speak. This is a simulation of a human-executed system; memorability is a real requirement.
 
-## 5. Run architecture and storage (REVIEW ITEM)
+## 5. Run architecture and storage (APPROVED — implemented in `8f3bee4`)
 
 **Principle: determinism makes the manifest the archive.** A run is fully reproducible from `{strategySpec, B, rolls, seeds, engineVersion (git sha)}` — a few hundred bytes. Therefore:
 

--- a/scripts/bit-identity-check.sh
+++ b/scripts/bit-identity-check.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Bit-identity gate: byte-compare run-sim CATS JSONL between the working
+# tree and a git ref (default HEAD~1).
+#
+#   scripts/bit-identity-check.sh [ref] [seeds] [rolls] [bankroll]
+#
+# Runs `run-sim --strategy CATS --rolls <rolls> --bankroll <bankroll>
+# --seed <s> --output json` for seeds 0..seeds-1 on both versions and diffs
+# byte-for-byte. Exits 0 and prints IDENTICAL only if every seed matches.
+#
+# The single normalization applied before comparing: the summary line's
+# `timestamp` field (wall-clock time of the run, not simulation output) is
+# stripped. Every roll record is compared without any normalization.
+set -euo pipefail
+
+normalize() {
+  sed 's/"timestamp":"[^"]*"/"timestamp":"X"/'
+}
+
+REF="${1:-HEAD~1}"
+SEEDS="${2:-100}"
+ROLLS="${3:-300}"
+BANKROLL="${4:-300}"
+
+ROOT="$(git rev-parse --show-toplevel)"
+WORK="$(mktemp -d)"
+trap 'git -C "$ROOT" worktree remove --force "$WORK/ref" 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "Comparing working tree vs $REF (seeds 0-$((SEEDS-1)), $ROLLS rolls, \$$BANKROLL)"
+git -C "$ROOT" worktree add --detach "$WORK/ref" "$REF" >/dev/null
+ln -s "$ROOT/node_modules" "$WORK/ref/node_modules"
+
+mkdir -p "$WORK/a" "$WORK/b"
+for ((s=0; s<SEEDS; s++)); do
+  (cd "$ROOT"      && npx ts-node src/cli/run-sim.ts --strategy CATS --rolls "$ROLLS" --bankroll "$BANKROLL" --seed "$s" --output json) | normalize > "$WORK/a/$s.jsonl"
+  (cd "$WORK/ref"  && npx ts-node src/cli/run-sim.ts --strategy CATS --rolls "$ROLLS" --bankroll "$BANKROLL" --seed "$s" --output json) | normalize > "$WORK/b/$s.jsonl"
+  if ! cmp -s "$WORK/a/$s.jsonl" "$WORK/b/$s.jsonl"; then
+    echo "DIFFERS at seed $s:"
+    diff <(head -c 2000 "$WORK/a/$s.jsonl") <(head -c 2000 "$WORK/b/$s.jsonl") | head -20 || true
+    exit 1
+  fi
+done
+
+echo "IDENTICAL across $SEEDS seeds"

--- a/scripts/dual-path-check.ts
+++ b/scripts/dual-path-check.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env npx ts-node
+/**
+ * Dual-path gate (session-lifecycle.md v4 §3 / Phase 3 item 6):
+ * for one config (500 seeds), compute the stopping-rule menu two ways —
+ * the streaming evaluator scoring sessions as they are produced, and an
+ * independent post-hoc truncation of archived JSONL trajectories — and
+ * assert the reports match EXACTLY.
+ *
+ *   npx ts-node scripts/dual-path-check.ts [seeds] [rolls] [bankroll] [spec]
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildStoppingContext,
+  runSessionsWithFactory,
+  streamSession,
+  SessionView,
+} from '../src/cli/analyze-stages';
+import { StreamingStoppingEvaluator, evaluateStoppingPostHoc, TrajectoryView } from '../src/cli/stopping-rules';
+import { createStrategy } from '../src/cli/strategy-registry';
+import { runSim } from '../src/cli/run-sim';
+
+const SEEDS = Number(process.argv[2] ?? 500);
+const ROLLS = Number(process.argv[3] ?? 300);
+const BANKROLL = Number(process.argv[4] ?? 300);
+const SPEC = process.argv[5] ?? 'CATS';
+
+const args = { strategy: SPEC, rolls: ROLLS, bankroll: BANKROLL, seeds: SEEDS, stopAtRuin: true };
+const { config, stateLevel } = buildStoppingContext(args);
+
+// --- Path 1: streaming, scored during simulation -------------------------
+console.error(`[1/3] Streaming path: ${SEEDS} sessions of ${SPEC} (${ROLLS} rolls, $${BANKROLL})...`);
+const evaluator = new StreamingStoppingEvaluator(config);
+runSessionsWithFactory(
+  () => createStrategy(SPEC), args,
+  (s: SessionView) => streamSession(evaluator, s, stateLevel),
+);
+const streaming = evaluator.report();
+
+// --- Path 2: archive JSONL trajectories, then post-hoc truncation --------
+// Archive via run-sim (the real JSONL producer), then re-load and truncate.
+console.error(`[2/3] Archiving ${SEEDS} JSONL trajectories via run-sim and truncating post hoc...`);
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dual-path-'));
+const trajectories: TrajectoryView[] = [];
+
+/** Run the real JSONL producer (run-sim + RunLogger) in-process, capturing stdout. */
+function archiveRun(seed: number): string {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (msg?: unknown) => { lines.push(String(msg)); };
+  try {
+    runSim({
+      strategy: SPEC, rolls: ROLLS, bankroll: BANKROLL, seed,
+      output: 'json',
+    } as any);
+  } finally {
+    console.log = original;
+  }
+  return lines.join('\n') + '\n';
+}
+
+for (let seed = 0; seed < SEEDS; seed++) {
+  const out = archiveRun(seed);
+  fs.writeFileSync(path.join(dir, `seed-${seed}.jsonl`), out);
+
+  const equity: number[] = [];
+  const stageLevels: number[] = [];
+  let sawBets = false;
+  for (const line of out.split('\n')) {
+    if (!line) continue;
+    const record = JSON.parse(line);
+    if (record.type !== 'roll') continue;
+    const p = record.players[0];
+    equity.push(p.bankroll.after + (p.tableLoad?.after ?? 0));
+    if ((p.activeBets?.length ?? 0) > 0) sawBets = true;
+    if (stateLevel) stageLevels.push(stateLevel.get(p.stagePlayed ?? p.stageName) ?? -1);
+  }
+  // run-sim has no stop-at-ruin flag; truncate the archived trajectory at
+  // ruin the same way the engine ends it: the first roll that begins with
+  // nothing on the felt ends the session (that roll is still recorded).
+  let end = equity.length;
+  for (const line of out.split('\n')) {
+    if (!line) continue;
+    const record = JSON.parse(line);
+    if (record.type !== 'roll') continue;
+    const p = record.players[0];
+    if ((p.activeBets?.length ?? 0) === 0 && (p.tableLoad?.before ?? 0) === 0) {
+      end = record.roll.number;
+      break;
+    }
+  }
+  const truncated = equity.slice(0, end);
+  trajectories.push({
+    equity: truncated,
+    ...(stateLevel ? { stageLevel: stageLevels.slice(0, end) } : {}),
+    endedAtRuin: sawBets && end < ROLLS,
+  });
+}
+const postHoc = evaluateStoppingPostHoc(trajectories, config);
+
+// --- Compare ---------------------------------------------------------------
+console.error('[3/3] Comparing reports...');
+const a = JSON.stringify(streaming, null, 2);
+const b = JSON.stringify(postHoc, null, 2);
+if (a === b) {
+  console.log(`DUAL-PATH GATE PASSED: streaming === post-hoc truncation for ${SEEDS} seeds (${SPEC}, ${ROLLS} rolls, $${BANKROLL})`);
+  fs.rmSync(dir, { recursive: true, force: true });
+} else {
+  console.log('DUAL-PATH GATE FAILED — first difference:');
+  const al = a.split('\n');
+  const bl = b.split('\n');
+  for (let i = 0; i < Math.max(al.length, bl.length); i++) {
+    if (al[i] !== bl[i]) {
+      console.log(`  streaming: ${al[i]}`);
+      console.log(`  post-hoc:  ${bl[i]}`);
+      break;
+    }
+  }
+  console.log(`JSONL kept at ${dir}`);
+  process.exit(1);
+}

--- a/server/lib/memo.ts
+++ b/server/lib/memo.ts
@@ -1,0 +1,39 @@
+/**
+ * In-memory LRU memoization for aggregate results, keyed by the stable hash
+ * of a run manifest minus generatedAt (session-lifecycle.md v4 §5).
+ *
+ * Determinism makes the manifest the archive: same manifest identity ⇒ same
+ * aggregates, so a repeated WebUI request is a cache hit or a fast recompute.
+ * The server never persists trajectories — only aggregates are memoized.
+ *
+ * TODO(v4 §5): an optional Firestore-backed cache behind a flag was
+ * considered, but Firestore is not among the server's existing dependencies
+ * — adding it would be new infrastructure. Revisit if/when the deploy
+ * gains a Firestore client for other reasons.
+ */
+export class LruCache<V> {
+  private map = new Map<string, V>();
+
+  constructor(private readonly maxEntries = 50) {}
+
+  get(key: string): V | undefined {
+    if (!this.map.has(key)) return undefined;
+    const value = this.map.get(key)!;
+    // Refresh recency: Map iteration order is insertion order.
+    this.map.delete(key);
+    this.map.set(key, value);
+    return value;
+  }
+
+  set(key: string, value: V): void {
+    if (this.map.has(key)) this.map.delete(key);
+    this.map.set(key, value);
+    if (this.map.size > this.maxEntries) {
+      this.map.delete(this.map.keys().next().value as string);
+    }
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+}

--- a/server/routes/distribution-compare.ts
+++ b/server/routes/distribution-compare.ts
@@ -1,18 +1,30 @@
 import { Request, Response } from 'express';
 import { SharedTable } from '../../src/engine/shared-table';
-import { BUILT_IN_STRATEGIES } from '../../src/cli/strategy-registry';
+import { createStrategy } from '../../src/cli/strategy-registry';
+import { buildManifest, manifestHash, RunManifest } from '../../src/cli/manifest';
 import { summarize, computeAggregates, SessionSummary } from '../lib/distribution';
+import { LruCache } from '../lib/memo';
+
+/** Memoized final aggregates keyed by the pair of manifest hashes (v4 §5). */
+const cache = new LruCache<{
+  baseline: ReturnType<typeof computeAggregates>;
+  test: ReturnType<typeof computeAggregates>;
+  manifests: RunManifest[];
+}>();
 
 export function distributionCompareStreamRoute(req: Request, res: Response): void {
   const { strategy, test, seeds, rolls, bankroll } = req.query as Record<string, string>;
 
-  if (!strategy || !BUILT_IN_STRATEGIES[strategy]) {
-    res.status(400).json({ error: `Unknown baseline strategy: "${strategy}". Available: ${Object.keys(BUILT_IN_STRATEGIES).join(', ')}` });
+  try {
+    createStrategy(strategy ?? '');
+  } catch (err: any) {
+    res.status(400).json({ error: `Baseline: ${err.message}` });
     return;
   }
-
-  if (!test || !BUILT_IN_STRATEGIES[test]) {
-    res.status(400).json({ error: `Unknown test strategy: "${test}". Available: ${Object.keys(BUILT_IN_STRATEGIES).join(', ')}` });
+  try {
+    createStrategy(test ?? '');
+  } catch (err: any) {
+    res.status(400).json({ error: `Test: ${err.message}` });
     return;
   }
 
@@ -39,8 +51,30 @@ export function distributionCompareStreamRoute(req: Request, res: Response): voi
   res.setHeader('Connection', 'keep-alive');
   res.flushHeaders();
 
-  const baselineFn = BUILT_IN_STRATEGIES[strategy];
-  const testFn = BUILT_IN_STRATEGIES[test];
+  const manifests = [strategy, test].map(spec => buildManifest({
+    strategySpec: spec,
+    bankroll: bankrollNum,
+    rolls: rollsNum,
+    seeds: { count: N },
+  }));
+  const key = manifests.map(manifestHash).join('+');
+
+  const cached = cache.get(key);
+  if (cached) {
+    const payload = JSON.stringify({
+      progress: 1,
+      completed: N,
+      baseline: cached.baseline,
+      test: cached.test,
+      manifests,
+      cached: true,
+      done: true,
+    });
+    res.write(`data: ${payload}\n\n`);
+    res.end();
+    return;
+  }
+
   const batchSize = Math.max(1, Math.floor(N / 10));
   const baselineResults: SessionSummary[] = [];
   const testResults: SessionSummary[] = [];
@@ -49,9 +83,10 @@ export function distributionCompareStreamRoute(req: Request, res: Response): voi
     if (res.destroyed) break;
 
     // Use SharedTable so both strategies see identical dice for each seed.
+    // Fresh instances per seed — stage machines carry runtime state.
     const table = new SharedTable({ seed: i, rolls: rollsNum });
-    table.addStrategy(strategy, baselineFn, { bankroll: bankrollNum });
-    table.addStrategy(test, testFn, { bankroll: bankrollNum });
+    table.addStrategy(strategy, createStrategy(strategy), { bankroll: bankrollNum });
+    table.addStrategy(test, createStrategy(test), { bankroll: bankrollNum });
     const sharedResult = table.run();
 
     const baselineEntry = sharedResult[strategy];
@@ -72,12 +107,19 @@ export function distributionCompareStreamRoute(req: Request, res: Response): voi
     }
 
     if ((i + 1) % batchSize === 0 || i === N - 1) {
+      const baselineAgg = computeAggregates(baselineResults);
+      const testAgg = computeAggregates(testResults);
+      const done = i === N - 1;
+      if (done && !res.destroyed) {
+        cache.set(key, { baseline: baselineAgg, test: testAgg, manifests });
+      }
       const payload = JSON.stringify({
         progress: (i + 1) / N,
         completed: i + 1,
-        baseline: computeAggregates(baselineResults),
-        test: computeAggregates(testResults),
-        done: i === N - 1,
+        baseline: baselineAgg,
+        test: testAgg,
+        manifests,
+        done,
       });
       res.write(`data: ${payload}\n\n`);
     }

--- a/server/routes/distribution.ts
+++ b/server/routes/distribution.ts
@@ -1,13 +1,22 @@
 import { Request, Response } from 'express';
 import { CrapsEngine } from '../../src/engine/craps-engine';
-import { BUILT_IN_STRATEGIES } from '../../src/cli/strategy-registry';
+import { createStrategy } from '../../src/cli/strategy-registry';
+import { buildManifest, manifestHash } from '../../src/cli/manifest';
 import { summarize, computeAggregates, SessionSummary } from '../lib/distribution';
+import { LruCache } from '../lib/memo';
+
+/** Memoized final aggregates keyed by manifest hash (v4 §5). */
+const cache = new LruCache<{ aggregates: ReturnType<typeof computeAggregates>; manifest: object }>();
 
 export function distributionStreamRoute(req: Request, res: Response): void {
   const { strategy, seeds, rolls, bankroll } = req.query as Record<string, string>;
 
-  if (!strategy || !BUILT_IN_STRATEGIES[strategy]) {
-    res.status(400).json({ error: `Unknown strategy: "${strategy}". Available: ${Object.keys(BUILT_IN_STRATEGIES).join(', ')}` });
+  // Spec-aware validation: NAME[@key=value,...]. createStrategy throws a
+  // descriptive error for unknown names, options, and entry slugs.
+  try {
+    createStrategy(strategy ?? '');
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
     return;
   }
 
@@ -34,7 +43,29 @@ export function distributionStreamRoute(req: Request, res: Response): void {
   res.setHeader('Connection', 'keep-alive');
   res.flushHeaders();
 
-  const strategyFn = BUILT_IN_STRATEGIES[strategy];
+  const manifest = buildManifest({
+    strategySpec: strategy,
+    bankroll: bankrollNum,
+    rolls: rollsNum,
+    seeds: { count: N },
+  });
+  const key = manifestHash(manifest);
+
+  const cached = cache.get(key);
+  if (cached) {
+    const payload = JSON.stringify({
+      progress: 1,
+      completed: N,
+      aggregates: cached.aggregates,
+      manifest,
+      cached: true,
+      done: true,
+    });
+    res.write(`data: ${payload}\n\n`);
+    res.end();
+    return;
+  }
+
   const batchSize = Math.max(1, Math.floor(N / 10));
   const allResults: SessionSummary[] = [];
 
@@ -42,7 +73,8 @@ export function distributionStreamRoute(req: Request, res: Response): void {
     if (res.destroyed) break;
 
     const engine = new CrapsEngine({
-      strategy: strategyFn,
+      // Fresh instance per session — stage machines carry runtime state.
+      strategy: createStrategy(strategy),
       bankroll: bankrollNum,
       rolls: rollsNum,
       seed: i,
@@ -51,11 +83,17 @@ export function distributionStreamRoute(req: Request, res: Response): void {
     allResults.push(summarize(engine.run(), i));
 
     if ((i + 1) % batchSize === 0 || i === N - 1) {
+      const aggregates = computeAggregates(allResults);
+      const done = i === N - 1;
+      if (done && !res.destroyed) {
+        cache.set(key, { aggregates, manifest });
+      }
       const payload = JSON.stringify({
         progress: (i + 1) / N,
         completed: i + 1,
-        aggregates: computeAggregates(allResults),
-        done: i === N - 1,
+        aggregates,
+        manifest,
+        done,
       });
       res.write(`data: ${payload}\n\n`);
     }

--- a/server/routes/simulate.ts
+++ b/server/routes/simulate.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { CrapsEngine } from '../../src/engine/craps-engine';
-import { BUILT_IN_STRATEGIES } from '../../src/cli/strategy-registry';
+import { BUILT_IN_STRATEGIES, createStrategy } from '../../src/cli/strategy-registry';
 
 export function simulateRoute(req: Request, res: Response): void {
   const { strategy, rolls, bankroll, seed } = req.body as {
@@ -10,8 +10,14 @@ export function simulateRoute(req: Request, res: Response): void {
     seed?: unknown;
   };
 
-  if (typeof strategy !== 'string' || !BUILT_IN_STRATEGIES[strategy]) {
+  if (typeof strategy !== 'string') {
     res.status(400).json({ error: `Unknown strategy: "${strategy}". Available: ${Object.keys(BUILT_IN_STRATEGIES).join(', ')}` });
+    return;
+  }
+  try {
+    createStrategy(strategy);
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
     return;
   }
 
@@ -33,7 +39,8 @@ export function simulateRoute(req: Request, res: Response): void {
   const resolvedSeed = seed !== undefined ? (seed as number) : Math.floor(Math.random() * 1_000_000);
 
   const engine = new CrapsEngine({
-    strategy: BUILT_IN_STRATEGIES[strategy],
+    // Fresh instance per request — stage machines carry runtime state.
+    strategy: createStrategy(strategy),
     bankroll,
     rolls,
     seed: resolvedSeed,

--- a/server/routes/strategies.ts
+++ b/server/routes/strategies.ts
@@ -1,6 +1,16 @@
 import { Request, Response } from 'express';
-import { BUILT_IN_STRATEGIES } from '../../src/cli/strategy-registry';
+import { listStrategyNames, getStrategyMetadata } from '../../src/cli/strategy-registry';
 
-export function strategiesRoute(_req: Request, res: Response): void {
-  res.json(Object.keys(BUILT_IN_STRATEGIES));
+/**
+ * Strategy catalog. Returns names (back-compat: an array of strings unless
+ * ?metadata=1), or the full per-strategy stage metadata — ordered slugs,
+ * display names, entry gates — so the UI can render a funded-entry dropdown
+ * generically for any staged strategy (v4 §2).
+ */
+export function strategiesRoute(req: Request, res: Response): void {
+  if (req.query.metadata === '1') {
+    res.json(listStrategyNames().map(name => getStrategyMetadata(name)));
+    return;
+  }
+  res.json(listStrategyNames());
 }

--- a/spec/cli/analyze-stages-spec.ts
+++ b/spec/cli/analyze-stages-spec.ts
@@ -112,7 +112,10 @@ describe('analyze-stages CLI', () => {
         strategy: 'CATS', rolls: 60, bankroll: 300, seeds: 8,
         stopAtRuin: true, output: 'json',
       });
-      expect(entries[0].report).toEqual(standalone);
+      // generatedAt is a wall-clock stamp — it is excluded from run identity
+      // (manifestHash) and from determinism comparisons.
+      const stripStamp = (r: any) => ({ ...r, manifest: { ...r.manifest, generatedAt: 'X' } });
+      expect(stripStamp(entries[0].report)).toEqual(stripStamp(standalone));
       // Stopping menu present per spec.
       expect(entries[0].report.stopping).toBeDefined();
       expect(entries[1].report.stopping).toBeDefined();
@@ -136,11 +139,13 @@ describe('analyze-stages CLI', () => {
       // Time percentages sum to ~100.
       const totalTime = report.stages.reduce((sum, s) => sum + s.timeInStagePct, 0);
       expect(totalTime).toBeCloseTo(100, 6);
-      // Deterministic: same seeds → same report.
+      // Deterministic: same seeds → same report (generatedAt is wall-clock
+      // and excluded from run identity).
       const again = runAnalysis({
         strategy: 'CATS', rolls: 200, bankroll: 300, seeds: 10, stopAtRuin: true, output: 'json',
       });
-      expect(again).toEqual(report);
+      const stripStamp = (r: any) => ({ ...r, manifest: { ...r.manifest, generatedAt: 'X' } });
+      expect(stripStamp(again)).toEqual(stripStamp(report));
     });
   });
 });

--- a/spec/cli/analyze-stages-spec.ts
+++ b/spec/cli/analyze-stages-spec.ts
@@ -1,4 +1,4 @@
-import { parseArgs, aggregate, runAnalysis } from '../../src/cli/analyze-stages';
+import { parseArgs, aggregate, runAnalysis, runComparison } from '../../src/cli/analyze-stages';
 
 describe('analyze-stages CLI', () => {
 
@@ -84,6 +84,38 @@ describe('analyze-stages CLI', () => {
       expect(report.pctSessionsPositive).toBe(50);
       expect(report.pctSessionsRuined).toBe(50);
       expect(report.pnl.p50).toBeCloseTo(-47.5, 6);
+    });
+  });
+
+  describe('multi-spec comparison mode', () => {
+    it('parses repeated --strategy flags in order', () => {
+      const args = parseArgs([
+        '--strategy', 'CATS@entry=accumulator',
+        '--strategy', 'CATS@entry=threePtMollyLoose',
+        '--seeds', '5', '--rolls', '50',
+      ]);
+      expect(args.strategies).toEqual(['CATS@entry=accumulator', 'CATS@entry=threePtMollyLoose']);
+      expect(args.strategy).toBe('CATS@entry=accumulator');
+    });
+
+    it('runs all specs on shared seeds and labels columns with canonical specs', () => {
+      const args = parseArgs([
+        '--strategy', 'CATS', '--strategy', 'CATS@entry=threePtMollyLoose',
+        '--seeds', '8', '--rolls', '60', '--bankroll', '300', '--stop-at-ruin',
+      ]);
+      const entries = runComparison(args);
+      expect(entries.map(e => e.spec)).toEqual(['CATS', 'CATS@entry=threePtMollyLoose']);
+      expect(entries[0].report.sessions).toBe(8);
+      expect(entries[1].report.sessions).toBe(8);
+      // Shared seeds: the first spec's report equals a standalone run of it.
+      const standalone = runAnalysis({
+        strategy: 'CATS', rolls: 60, bankroll: 300, seeds: 8,
+        stopAtRuin: true, output: 'json',
+      });
+      expect(entries[0].report).toEqual(standalone);
+      // Stopping menu present per spec.
+      expect(entries[0].report.stopping).toBeDefined();
+      expect(entries[1].report.stopping).toBeDefined();
     });
   });
 

--- a/spec/cli/manifest-spec.ts
+++ b/spec/cli/manifest-spec.ts
@@ -1,0 +1,52 @@
+import { buildManifest, manifestHash, MANIFEST_SCHEMA_VERSION } from '../../src/cli/manifest';
+import { LruCache } from '../../server/lib/memo';
+
+describe('run manifest (v4 §5)', () => {
+  it('embeds the canonical spec, tableMin, and engine version', () => {
+    const m = buildManifest({
+      strategySpec: 'CATS@tableMin=15,entry=littleMolly',
+      bankroll: 450,
+      rolls: 300,
+      seeds: { count: 100 },
+    });
+    expect(m.schemaVersion).toBe(MANIFEST_SCHEMA_VERSION);
+    expect(m.strategySpec).toBe('CATS@entry=littleMolly,tableMin=15'); // canonicalized
+    expect(m.tableMin).toBe(15); // derived from the spec
+    expect(m.bankroll).toBe(450);
+    expect(m.rolls).toBe(300);
+    expect(m.seeds).toEqual({ count: 100 });
+    expect(m.engineVersion.length).toBeGreaterThan(0);
+    expect(() => new Date(m.generatedAt)).not.toThrow();
+  });
+
+  it('defaults tableMin to 10 when the spec does not carry it', () => {
+    const m = buildManifest({ strategySpec: 'CATS', bankroll: 300, rolls: 300, seeds: { seed: 7 } });
+    expect(m.tableMin).toBe(10);
+    expect(m.strategySpec).toBe('CATS');
+  });
+
+  it('hash is stable across generatedAt and key order, and sensitive to identity fields', () => {
+    const a = buildManifest({ strategySpec: 'CATS', bankroll: 300, rolls: 300, seeds: { count: 10 } });
+    const b = { ...a, generatedAt: '1999-01-01T00:00:00Z' };
+    expect(manifestHash(b as any)).toBe(manifestHash(a));
+
+    const c = { ...a, bankroll: 301 };
+    expect(manifestHash(c as any)).not.toBe(manifestHash(a));
+    const d = { ...a, strategySpec: 'CATS@entry=littleMolly' };
+    expect(manifestHash(d as any)).not.toBe(manifestHash(a));
+  });
+});
+
+describe('LruCache', () => {
+  it('evicts the least-recently-used entry at capacity', () => {
+    const lru = new LruCache<number>(2);
+    lru.set('a', 1);
+    lru.set('b', 2);
+    lru.get('a');        // refresh a — b is now oldest
+    lru.set('c', 3);     // evicts b
+    expect(lru.get('a')).toBe(1);
+    expect(lru.get('b')).toBeUndefined();
+    expect(lru.get('c')).toBe(3);
+    expect(lru.size).toBe(2);
+  });
+});

--- a/spec/cli/stopping-rules-spec.ts
+++ b/spec/cli/stopping-rules-spec.ts
@@ -1,0 +1,170 @@
+/**
+ * Stopping-rule evaluator — dual-path validation (v4 §3).
+ *
+ * The streaming evaluator (incremental per-roll state) and the post-hoc
+ * truncation evaluator (whole-trajectory scans) are independent
+ * implementations; their reports must match EXACTLY on the same sessions.
+ * The full mandated config (500 seeds) runs in scripts/dual-path-check.ts;
+ * this in-suite gate runs a smaller deterministic slice of the same check.
+ */
+import {
+  StreamingStoppingEvaluator,
+  evaluateStoppingPostHoc,
+  TrajectoryView,
+  StoppingConfig,
+} from '../../src/cli/stopping-rules';
+import {
+  runAnalysis,
+  buildStoppingContext,
+  runSessionsWithFactory,
+  streamSession,
+  SessionView,
+} from '../../src/cli/analyze-stages';
+import { createStrategy } from '../../src/cli/strategy-registry';
+
+function toTrajectories(sessions: SessionView[], stateLevel: Map<string, number> | null): TrajectoryView[] {
+  return sessions.map(s => ({
+    equity: s.rolls.map(r => r.equityAfter),
+    ...(stateLevel ? { stageLevel: s.rolls.map(r => stateLevel.get(r.stageName) ?? -1) } : {}),
+    endedAtRuin: s.endedAtRuin,
+  }));
+}
+
+describe('stopping-rule evaluator', () => {
+
+  describe('dual-path gate: streaming === post-hoc truncation', () => {
+    it('matches exactly for CATS (60 seeds, 200 rolls, $300)', () => {
+      const args = { strategy: 'CATS', rolls: 200, bankroll: 300, seeds: 60, stopAtRuin: true };
+      const { config, stateLevel } = buildStoppingContext(args);
+
+      const evaluator = new StreamingStoppingEvaluator(config);
+      const sessions = runSessionsWithFactory(
+        () => createStrategy('CATS'), args,
+        s => streamSession(evaluator, s, stateLevel),
+      );
+
+      const streaming = evaluator.report();
+      const postHoc = evaluateStoppingPostHoc(toTrajectories(sessions, stateLevel), config);
+      expect(streaming).toEqual(postHoc);
+    });
+
+    it('matches exactly for a funded entry with a custom trail drop', () => {
+      const args = {
+        strategy: 'CATS@entry=threePtMollyTight', rolls: 150, bankroll: 200,
+        seeds: 40, stopAtRuin: true, trailDrop: 50,
+      };
+      const { config, stateLevel } = buildStoppingContext(args);
+      expect(config.trailDrop).toBe(50);
+
+      const evaluator = new StreamingStoppingEvaluator(config);
+      const sessions = runSessionsWithFactory(
+        () => createStrategy(args.strategy), args,
+        s => streamSession(evaluator, s, stateLevel),
+      );
+
+      const streaming = evaluator.report();
+      const postHoc = evaluateStoppingPostHoc(toTrajectories(sessions, stateLevel), config);
+      expect(streaming).toEqual(postHoc);
+    });
+  });
+
+  describe("rule 'none' reproduces the session P&L metrics to the dollar", () => {
+    it('banked P&L quantiles and % positive equal the session report', () => {
+      const report = runAnalysis({
+        strategy: 'CATS', rolls: 200, bankroll: 300, seeds: 50,
+        stopAtRuin: true, output: 'json',
+      });
+      const none = report.stopping!.rules.find(r => r.rule === 'none')!;
+      expect(none.triggerRate).toBe(0);
+      expect(none.banked.p10).toBe(report.pnl.p10);
+      expect(none.banked.p50).toBe(report.pnl.p50);
+      expect(none.banked.p90).toBe(report.pnl.p90);
+      expect(none.pctPositive).toBe(report.pctSessionsPositive);
+      expect(100 * none.ruinRate).toBeCloseTo(report.pctSessionsRuined, 10);
+    });
+  });
+
+  describe('rule semantics on hand-built trajectories', () => {
+    const config: StoppingConfig = { bankroll: 100, trailDrop: 30, belowStageLevel: 2, belowStageSlug: 'stageC' };
+
+    function evalOne(t: TrajectoryView) {
+      const streaming = new StreamingStoppingEvaluator(config);
+      streaming.beginSession();
+      t.equity.forEach((e, i) => streaming.onRoll(e, t.stageLevel?.[i]));
+      streaming.endSession(t.equity[t.equity.length - 1], t.endedAtRuin);
+      const s = streaming.report();
+      const p = evaluateStoppingPostHoc([t], config);
+      expect(s).toEqual(p); // every hand case double-checks the dual path
+      return s;
+    }
+
+    it('hard target banks the equity of the crossing roll', () => {
+      const r = evalOne({
+        equity: [150, 120, 210, 260, 80],
+        stageLevel: [2, 2, 2, 2, 2],
+        endedAtRuin: false,
+      });
+      const t2 = r.rules.find(x => x.rule === 'target-2x')!;
+      expect(t2.triggerRate).toBe(1);
+      expect(t2.banked.p50).toBe(110); // 210 − 100 at the ≥200 crossing
+    });
+
+    it('trailing floor banks peak − observed drop at the breach', () => {
+      const r = evalOne({
+        equity: [150, 180, 149, 140],
+        stageLevel: [2, 2, 2, 2],
+        endedAtRuin: false,
+      });
+      const trail = r.rules.find(x => x.rule === 'trail')!;
+      // Peak 180; fires at 149 (≤ 180 − 30) → banked 49.
+      expect(trail.triggerRate).toBe(1);
+      expect(trail.banked.p50).toBe(49);
+    });
+
+    it('below-stage arms at/above the level and fires on the fall', () => {
+      const r = evalOne({
+        equity: [110, 120, 115, 90],
+        stageLevel: [1, 2, 3, 1], // arms at level 2, falls to 1 on roll 4
+        endedAtRuin: false,
+      });
+      const below = r.rules.find(x => x.rule === 'below-stage')!;
+      expect(below.triggerRate).toBe(1);
+      expect(below.banked.p50).toBe(-10); // equity 90 at the fall
+    });
+
+    it('below-stage never fires when the session never reaches the level', () => {
+      const r = evalOne({
+        equity: [90, 80, 70],
+        stageLevel: [1, 1, 0],
+        endedAtRuin: false,
+      });
+      const below = r.rules.find(x => x.rule === 'below-stage')!;
+      expect(below.triggerRate).toBe(0);
+      expect(below.censoredRate).toBe(1);
+    });
+
+    it('roll caps bank the equity at the cap; ruin before the cap is ruin', () => {
+      const shortRuin: TrajectoryView = {
+        equity: [60, 20, 0],
+        stageLevel: [1, 1, 1],
+        endedAtRuin: true,
+      };
+      const r = evalOne(shortRuin);
+      const cap100 = r.rules.find(x => x.rule === 'cap-100')!;
+      expect(cap100.triggerRate).toBe(0);
+      expect(cap100.ruinRate).toBe(1);
+      expect(cap100.banked.p50).toBe(-100);
+    });
+
+    it('peak-equity distribution is reported from the running peak', () => {
+      const r = evalOne({
+        equity: [150, 300, 100],
+        stageLevel: [2, 2, 2],
+        endedAtRuin: false,
+      });
+      expect(r.peakPnl.p50).toBe(200); // peak 300 − B 100
+      const hit2 = r.hitting.find(h => h.k === 2)!;
+      expect(hit2.pHitBeforeRuin).toBe(1); // 300 ≥ 2·100 before any ruin
+    });
+  });
+});

--- a/spec/cli/strategy-spec-spec.ts
+++ b/spec/cli/strategy-spec-spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Canonical strategy specs (NAME@key=value[,key=value]) and stage metadata
+ * export — session-lifecycle.md v4 §2.
+ */
+import { parseStrategySpec, canonicalizeSpec } from '../../src/cli/strategy-loader';
+import { createStrategy, getStrategyMetadata } from '../../src/cli/strategy-registry';
+import { STAGE_MACHINE_RUNTIME } from '../../src/dsl/strategy';
+import { StageMachineRuntime } from '../../src/dsl/stage-machine-state';
+
+function runtimeOf(strategy: any): StageMachineRuntime {
+  return strategy[STAGE_MACHINE_RUNTIME];
+}
+
+describe('canonical strategy specs', () => {
+
+  describe('parseStrategySpec', () => {
+    it('parses a bare name', () => {
+      const p = parseStrategySpec('CATS');
+      expect(p.name).toBe('CATS');
+      expect(p.options).toEqual({});
+      expect(p.canonical).toBe('CATS');
+    });
+
+    it('parses entry and tableMin', () => {
+      const p = parseStrategySpec('CATS@entry=threePtMollyLoose,tableMin=15');
+      expect(p.name).toBe('CATS');
+      expect(p.options).toEqual({ entry: 'threePtMollyLoose', tableMin: 15 });
+    });
+
+    it('normalizes key order to the canonical form', () => {
+      const p = parseStrategySpec('CATS@tableMin=15,entry=littleMolly');
+      expect(p.canonical).toBe('CATS@entry=littleMolly,tableMin=15');
+    });
+
+    it('round-trips: parse(canonical).canonical === canonical', () => {
+      for (const spec of ['CATS', 'CATS@entry=threePtMollyLoose', 'BATS@entry=threePtDolly,tableMin=15']) {
+        const once = parseStrategySpec(spec).canonical;
+        expect(parseStrategySpec(once).canonical).toBe(once);
+      }
+    });
+
+    it('rejects unknown keys with the valid list', () => {
+      expect(() => parseStrategySpec('CATS@foo=1'))
+        .toThrowError(/unknown option "foo".*entry, tableMin/);
+    });
+
+    it('rejects malformed specs', () => {
+      expect(() => parseStrategySpec('CATS@')).toThrow();
+      expect(() => parseStrategySpec('CATS@entry')).toThrow();
+      expect(() => parseStrategySpec('CATS@entry=')).toThrow();
+      expect(() => parseStrategySpec('CATS@entry=a,entry=b')).toThrow();
+      expect(() => parseStrategySpec('CATS@tableMin=zero')).toThrow();
+      expect(() => parseStrategySpec('@entry=a')).toThrow();
+    });
+
+    it('canonicalizeSpec renders bare name when there are no options', () => {
+      expect(canonicalizeSpec('CATS', {})).toBe('CATS');
+    });
+  });
+
+  describe('createStrategy with specs', () => {
+    it('creates a funded-entry CATS from a spec string', () => {
+      const s = createStrategy('CATS@entry=threePtMollyLoose');
+      expect(runtimeOf(s).getCurrentStage()).toBe('threePtMollyLoose');
+    });
+
+    it('maps the accumulator slug to the accumulatorFull state', () => {
+      const s = createStrategy('CATS@entry=accumulator');
+      expect(runtimeOf(s).getCurrentStage()).toBe('accumulatorFull');
+    });
+
+    it('applies tableMin through the spec', () => {
+      const s = createStrategy('CATS@entry=littleMolly,tableMin=15');
+      // $15 littleMolly gate is $105; funded entry starts profit at the gate
+      // once the bankroll is captured — verify via the runtime's metadata.
+      const meta = runtimeOf(s).getStageMetadata();
+      expect(meta.find(m => m.slug === 'littleMolly')!.gate).toBe(105);
+    });
+
+    it('fails loudly on unknown entry slugs, listing the valid slugs', () => {
+      expect(() => createStrategy('CATS@entry=bogusStage'))
+        .toThrowError(/unknown entry stage "bogusStage".*accumulator, littleMolly, threePtMollyTight, threePtMollyLoose, expandedAlpha, maxAlpha/);
+    });
+
+    it('fails loudly when options are passed to a non-parameterized strategy', () => {
+      expect(() => createStrategy('PassLineOnly@entry=foo'))
+        .toThrowError(/does not accept spec options/);
+    });
+
+    it('fails loudly on unknown strategy names', () => {
+      expect(() => createStrategy('NotAStrategy')).toThrowError(/Unknown strategy/);
+    });
+  });
+
+  describe('getStrategyMetadata', () => {
+    it('exports the CATS ladder in order with display names and gates', () => {
+      const meta = getStrategyMetadata('CATS');
+      expect(meta.parameterized).toBe(true);
+      expect(meta.stages.map(s => s.slug)).toEqual([
+        'accumulator', 'littleMolly', 'threePtMollyTight',
+        'threePtMollyLoose', 'expandedAlpha', 'maxAlpha',
+      ]);
+      expect(meta.stages.map(s => s.displayName)).toEqual([
+        'Accumulator', 'Little Molly', '3-Point Molly — Tight',
+        '3-Point Molly — Loose', 'Expanded Alpha', 'Max Alpha',
+      ]);
+      expect(meta.stages.map(s => s.gate)).toEqual([0, 70, 150, 250, 250, 400]);
+    });
+
+    it('exports the BATS Dolly ladder generically', () => {
+      const meta = getStrategyMetadata('BATS');
+      expect(meta.stages.map(s => s.slug)).toEqual([
+        'bearishAccumulator', 'littleDolly', 'threePtDolly',
+        'expandedDarkAlpha', 'maxDarkAlpha',
+      ]);
+      expect(meta.stages.map(s => s.gate)).toEqual([0, 120, 225, 350, 500]);
+    });
+
+    it('returns an empty stage list for non-staged strategies', () => {
+      const meta = getStrategyMetadata('PassLineOnly');
+      expect(meta.stages).toEqual([]);
+      expect(meta.parameterized).toBe(false);
+    });
+  });
+});

--- a/spec/dsl/cats-strategy-spec.ts
+++ b/spec/dsl/cats-strategy-spec.ts
@@ -219,12 +219,16 @@ describe('CATS strategy (Stage Machine implementation)', () => {
       expect(result).toBe('littleMolly');
     });
 
-    it('hard-resets to AccumulatorRegressed below +$20', () => {
+    it('deep losses retreat one link at a time — the chain, not a hard reset', () => {
+      // The former §3.4 hard reset (profit < +$20 → jump to Accumulator)
+      // is retired (v4 decision #3). A deep crash returns littleMolly from
+      // this stage; evaluateRetreats chains the descent to the Accumulator
+      // in the same evaluation (see the no-dead-zone spec below).
       const strategy = CATS();
       const runtime = getRuntime(strategy);
       const config = (runtime as any).stageConfigs.get('threePtMollyTight');
       const result = config.mustRetreatTo({ profit: 10, consecutiveSevenOuts: 0, sevenOutStepDownTriggered: false, handsPlayed: 10, stage: 'threePtMollyTight' });
-      expect(result).toBe('accumulatorRegressed');
+      expect(result).toBe('littleMolly');
     });
   });
 
@@ -290,12 +294,12 @@ describe('CATS strategy (Stage Machine implementation)', () => {
       expect(result).toBe('threePtMollyLoose');
     });
 
-    it('hard-resets to AccumulatorRegressed below +$20', () => {
+    it('deep losses retreat one link at a time — the chain, not a hard reset', () => {
       const strategy = CATS();
       const runtime = getRuntime(strategy);
       const config = (runtime as any).stageConfigs.get('expandedAlpha');
       const result = config.mustRetreatTo({ profit: 15, consecutiveSevenOuts: 0, sevenOutStepDownTriggered: false, handsPlayed: 10, stage: 'expandedAlpha' });
-      expect(result).toBe('accumulatorRegressed');
+      expect(result).toBe('threePtMollyLoose');
     });
   });
 
@@ -323,12 +327,12 @@ describe('CATS strategy (Stage Machine implementation)', () => {
       expect(result).toBe('expandedAlpha');
     });
 
-    it('hard-resets to AccumulatorRegressed below +$20', () => {
+    it('deep losses retreat one link at a time — the chain, not a hard reset', () => {
       const strategy = CATS();
       const runtime = getRuntime(strategy);
       const config = (runtime as any).stageConfigs.get('maxAlpha');
       const result = config.mustRetreatTo({ profit: 0, consecutiveSevenOuts: 0, sevenOutStepDownTriggered: false, handsPlayed: 10, stage: 'maxAlpha' });
-      expect(result).toBe('accumulatorRegressed');
+      expect(result).toBe('expandedAlpha');
     });
   });
 
@@ -419,7 +423,7 @@ describe('CATS strategy (Stage Machine implementation)', () => {
       expect(configs.get('expandedAlpha').canAdvanceTo('maxAlpha', s(400))).toBe(true);
     });
 
-    it('scales the higher gates proportionally, keeping the $20 hard reset fixed', () => {
+    it('scales the higher gates proportionally', () => {
       // stage2Gate $40 → f = 4/7: gates become $40/$86/$114/$143/$229.
       const runtime = getRuntime(CATS({ stage2Gate: 40 }));
       const configs = (runtime as any).stageConfigs;
@@ -431,9 +435,8 @@ describe('CATS strategy (Stage Machine implementation)', () => {
       expect(configs.get('threePtMollyLoose').canAdvanceTo('expandedAlpha', s(143))).toBe(true);
       expect(configs.get('expandedAlpha').canAdvanceTo('maxAlpha', s(229))).toBe(true);
       expect(configs.get('expandedAlpha').canAdvanceTo('maxAlpha', s(228))).toBe(false);
-      // Hard reset stays at $20 regardless of scale.
-      expect(configs.get('maxAlpha').mustRetreatTo(s(19))).toBe('accumulatorRegressed');
-      expect(configs.get('maxAlpha').mustRetreatTo(s(20))).toBe('expandedAlpha'); // < scaled $229 gate
+      // Hard reset retired: deep losses step down one link of the chain.
+      expect(configs.get('maxAlpha').mustRetreatTo(s(19))).toBe('expandedAlpha');
     });
   });
 
@@ -498,10 +501,42 @@ describe('CATS strategy (Stage Machine implementation)', () => {
       expect(runtime.getCurrentStage()).toBe('littleMolly');
     });
 
-    it('hard reset: profit below +$20 returns any stage to accumulatorRegressed', () => {
+    it('no dead zone: a deep crash from maxAlpha chains to the Accumulator in one evaluation', () => {
+      // Hard reset retired (v4 decision #3): the same observable endpoint is
+      // reached purely through the retreat chain. The floors (400/250/150/70)
+      // tile the profit axis with no gap, and evaluateRetreats loops, so
+      // profit 10 descends max → expanded → loose → little → accumulator
+      // before the next board is declared.
       const { strategy, runtime } = makeRuntimeAt('maxAlpha', 10);
       declaredBets(strategy);
       expect(runtime.getCurrentStage()).toBe('accumulatorRegressed');
+    });
+
+    it('no dead zone: every retreat floor tiles the profit axis from every stage', () => {
+      // For each stage and each profit just below each floor, the chain
+      // must terminate in the accumulator band or a stable stage — never
+      // loop and never strand. Exercise the full grid of floors ± $1.
+      const probes = [-60, 0, 19, 20, 69, 70, 149, 150, 199, 200, 249, 250, 399, 400];
+      const stages = ['littleMolly', 'threePtMollyTight', 'threePtMollyLoose', 'expandedAlpha', 'maxAlpha'];
+      for (const stage of stages) {
+        for (const profit of probes) {
+          const { strategy, runtime } = makeRuntimeAt(stage, profit);
+          declaredBets(strategy); // one reconcile: retreats evaluate, board runs
+          const landed = (runtime as any).currentStage as string;
+          const floors: Record<string, number> = {
+            accumulatorFull: -Infinity,
+            accumulatorRegressed: -Infinity,
+            littleMolly: 70,
+            threePtMollyTight: 150,
+            threePtMollyLoose: 200,
+            expandedAlpha: 250,
+            maxAlpha: 400,
+          };
+          expect(profit >= floors[landed])
+            .withContext(`${stage} @ ${profit} landed ${landed}`)
+            .toBe(true);
+        }
+      }
     });
   });
 

--- a/spec/dsl/funded-entry-spec.ts
+++ b/spec/dsl/funded-entry-spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Funded entry (session-lifecycle.md v4 §2) — origin-based profit.
+ *
+ * origin = bankroll − gate(entryStage); profit = equity − origin. Default
+ * entry (gate 0) reproduces classic behavior exactly (see the bit-identity
+ * gate in scripts/bit-identity-check.sh). The seven-out counter starts at
+ * zero regardless of entry stage.
+ */
+import { CrapsEngine } from '../../src/engine/craps-engine';
+import { RiggedDice } from '../dice/rigged-dice';
+import { STAGE_MACHINE_RUNTIME, StrategyDefinition } from '../../src/dsl/strategy';
+import { StageMachineRuntime } from '../../src/dsl/stage-machine-state';
+import { CATS } from '../../src/dsl/strategies-staged';
+
+function getRuntime(strategy: StrategyDefinition): StageMachineRuntime {
+  return (strategy as any)[STAGE_MACHINE_RUNTIME];
+}
+
+describe('funded entry (v4 §2)', () => {
+
+  it('default entry starts in accumulatorFull with origin = bankroll (profit 0)', () => {
+    const strategy = CATS();
+    const runtime = getRuntime(strategy);
+    expect(runtime.getCurrentStage()).toBe('accumulatorFull');
+    const dice = new RiggedDice([4]);
+    const engine = new CrapsEngine({ strategy, bankroll: 300, rolls: 1, dice });
+    engine.run();
+    // One point-set roll: equity unchanged (place bets at face) → profit 0.
+    expect(runtime.getSessionState().profit).toBe(0);
+  });
+
+  it("entry='accumulator' resolves the slug to accumulatorFull with gate 0", () => {
+    const strategy = CATS({ entry: 'accumulator' });
+    const runtime = getRuntime(strategy);
+    expect(runtime.getCurrentStage()).toBe('accumulatorFull');
+    const dice = new RiggedDice([4]);
+    const engine = new CrapsEngine({ strategy, bankroll: 300, rolls: 1, dice });
+    engine.run();
+    expect(runtime.getSessionState().profit).toBe(0);
+  });
+
+  it("CATS@entry=threePtMollyLoose at $300 occupies Loose on roll 1 with profit exactly $250 (origin $50)", () => {
+    const strategy = CATS({ entry: 'threePtMollyLoose' });
+    const runtime = getRuntime(strategy);
+    expect(runtime.getCurrentStage()).toBe('threePtMollyLoose');
+
+    // Roll 4 establishes a point: pass line placed at face, equity unchanged.
+    const dice = new RiggedDice([4]);
+    const engine = new CrapsEngine({ strategy, bankroll: 300, rolls: 1, dice });
+    const result = engine.run();
+
+    expect(result.rolls[0].stagePlayed).toBe('threePtMollyLoose');
+    // origin = 300 − 250 = 50; equity still 300 → profit 250.
+    expect(runtime.getSessionState().profit).toBe(250);
+    // Loose's gate is shared with expandedAlpha's (both 25u): profit at
+    // exactly the gate qualifies the ≥$250 advance — the stage after the
+    // roll is expandedAlpha (v4 decision #1: physics, not validation).
+    expect(runtime.getCurrentStage()).toBe('expandedAlpha');
+  });
+
+  it('a mid-ladder entry retreats through the chain on sustained losses', () => {
+    // Enter Expanded Alpha at $300 (origin $50, profit $250) and feed
+    // repeated point-then-seven-out cycles. Profit-threshold retreats walk
+    // the ladder down stage by stage until the Accumulator.
+    const strategy = CATS({ entry: 'expandedAlpha' });
+    const runtime = getRuntime(strategy);
+    expect(runtime.getCurrentStage()).toBe('expandedAlpha');
+
+    const rolls: number[] = [];
+    for (let i = 0; i < 20; i++) rolls.push(4, 7); // set point, seven out
+    const dice = new RiggedDice(rolls);
+    const engine = new CrapsEngine({ strategy, bankroll: 300, rolls: rolls.length, dice });
+    const result = engine.run();
+
+    // Lands in the Accumulator band...
+    expect(runtime.getCurrentStage()).toBe('accumulatorRegressed');
+    // ...and got there THROUGH the chain: intermediate boards were played.
+    const played = new Set(result.rolls.map(r => r.stagePlayed));
+    expect(played.has('expandedAlpha')).toBe(true);
+    expect(
+      played.has('threePtMollyLoose') || played.has('threePtMollyTight') || played.has('littleMolly')
+    ).toBe(true);
+  });
+
+  it('B below the entry gate (negative origin) is legal and runs', () => {
+    // $100 into Max Alpha: origin = 100 − 400 = −300 → profit starts at
+    // 400 with only $100 of runway. Documented experimental config —
+    // no validation beyond B > 0.
+    const strategy = CATS({ entry: 'maxAlpha' });
+    const runtime = getRuntime(strategy);
+    const dice = new RiggedDice([4]);
+    const engine = new CrapsEngine({ strategy, bankroll: 100, rolls: 1, dice });
+    expect(() => engine.run()).not.toThrow();
+    expect(runtime.getSessionState().profit).toBe(400);
+  });
+
+  it('the seven-out counter starts at zero regardless of entry stage', () => {
+    const runtime = getRuntime(CATS({ entry: 'expandedAlpha' }));
+    expect(runtime.getSessionState().consecutiveSevenOuts).toBe(0);
+    expect(runtime.getSessionState().sevenOutStepDownTriggered).toBe(false);
+  });
+
+  it('unknown entry slugs fail loudly with the valid list', () => {
+    expect(() => CATS({ entry: 'turboAccumulator' })).toThrowError(
+      /unknown entry stage "turboAccumulator".*accumulator, littleMolly, threePtMollyTight, threePtMollyLoose, expandedAlpha, maxAlpha/
+    );
+    // Internal machine states without entry metadata are not enterable.
+    expect(() => CATS({ entry: 'accumulatorRegressed' })).toThrow();
+  });
+});

--- a/spec/dsl/funded-entry-spec.ts
+++ b/spec/dsl/funded-entry-spec.ts
@@ -11,10 +11,46 @@ import { RiggedDice } from '../dice/rigged-dice';
 import { STAGE_MACHINE_RUNTIME, StrategyDefinition } from '../../src/dsl/strategy';
 import { StageMachineRuntime } from '../../src/dsl/stage-machine-state';
 import { CATS } from '../../src/dsl/strategies-staged';
+import { createStrategy } from '../../src/cli/strategy-registry';
 
 function getRuntime(strategy: StrategyDefinition): StageMachineRuntime {
   return (strategy as any)[STAGE_MACHINE_RUNTIME];
 }
+
+describe('funded entry — BATS generality acceptance (v4 §2, decision #7)', () => {
+  // The acceptance test for "general solution, not CATS solution": a funded
+  // BATS entry works purely through the stage-machine mechanism. BATS's only
+  // contribution is declarative stage metadata — no BATS-specific runtime
+  // code exists anywhere in the entry/origin/spec machinery.
+  it('BATS@entry=threePtDolly starts in the Dolly with profit at its $225 gate', () => {
+    const strategy = createStrategy('BATS@entry=threePtDolly');
+    const runtime = getRuntime(strategy);
+    expect(runtime.getCurrentStage()).toBe('threePtDolly');
+
+    // 4 (come-out: DP placed, point 4 on) — origin = 300 − 225 = 75,
+    // so profit = equity − origin = 225 at the start.
+    const dice = new RiggedDice([4]);
+    const engine = new CrapsEngine({ strategy, bankroll: 300, rolls: 1, dice });
+    const result = engine.run();
+    expect(result.rolls[0].stagePlayed).toBe('threePtDolly');
+    expect(runtime.getSessionState().profit).toBe(225);
+    expect(runtime.getSessionState().consecutiveSevenOuts).toBe(0);
+  });
+
+  it('a funded BATS entry retreats down the Dolly chain as profit falls', () => {
+    const strategy = createStrategy('BATS@entry=threePtDolly');
+    const runtime = getRuntime(strategy);
+    // Losing sequence for the don't side: points made repeatedly. Each made
+    // point loses the DP flat + lay odds, dropping profit through the $225
+    // (→ littleDolly) and $120 (→ bearishAccumulator) floors.
+    const rolls: number[] = [];
+    for (let i = 0; i < 12; i++) rolls.push(6, 6); // point 6 set, point made
+    const dice = new RiggedDice(rolls);
+    const engine = new CrapsEngine({ strategy, bankroll: 300, rolls: rolls.length, dice });
+    engine.run();
+    expect(runtime.getCurrentStage()).toBe('bearishAccumulator');
+  });
+});
 
 describe('funded entry (v4 §2)', () => {
 

--- a/spec/dsl/units-spec.ts
+++ b/spec/dsl/units-spec.ts
@@ -55,13 +55,12 @@ describe('unit system', () => {
       expect(u.tier.rough).toEqual({ passLine: 10, come1: 10, come2: 10 });
     });
 
-    it('buys $20; accumulator $18 → $12; mode shift $200; risk $300; hard reset $20', () => {
+    it('buys $20; accumulator $18 → $12; mode shift $200; risk $300', () => {
       expect(u.buyAmount).toBe(20);
       expect(u.accumulatorStart).toBe(18);
       expect(u.accumulatorRegressed).toBe(12);
       expect(u.modeShiftCushion).toBe(200);
       expect(u.classicRisk).toBe(300);
-      expect(u.hardReset).toBe(20);
     });
 
     it('reference funded configs (v4 §4): $200 @ Tight, $150 @ Little Molly', () => {

--- a/spec/dsl/units-spec.ts
+++ b/spec/dsl/units-spec.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit-system spec — the no-change proof.
+ *
+ * Every dollar figure in cats-strategy.md v1.2 must be reproduced exactly at
+ * $10 and $15 table minimums. If any figure at $10 differs from the doc,
+ * that is a regression in the unit module — fix the module, never this spec.
+ */
+import { catsUnits, batsUnits, minPlaceBet, placeStep } from '../../src/dsl/units';
+import { CATS } from '../../src/dsl/strategies-staged';
+import { CrapsEngine } from '../../src/engine/craps-engine';
+import { RiggedDice } from '../dice/rigged-dice';
+
+describe('unit system', () => {
+
+  describe('minPlaceBet', () => {
+    it('is the smallest proper multiple at or above the table minimum', () => {
+      expect(minPlaceBet(6, 10)).toBe(12);
+      expect(minPlaceBet(8, 10)).toBe(12);
+      expect(minPlaceBet(6, 15)).toBe(18);
+      expect(minPlaceBet(8, 15)).toBe(18);
+      expect(minPlaceBet(5, 10)).toBe(10);
+      expect(minPlaceBet(9, 10)).toBe(10);
+      expect(minPlaceBet(4, 15)).toBe(15);
+      expect(minPlaceBet(10, 15)).toBe(15);
+      expect(minPlaceBet(5, 25)).toBe(25);
+      expect(minPlaceBet(6, 25)).toBe(30);
+    });
+
+    it('placeStep is $6 on 6/8 and $5 elsewhere', () => {
+      expect(placeStep(6)).toBe(6);
+      expect(placeStep(8)).toBe(6);
+      [4, 5, 9, 10].forEach(n => expect(placeStep(n)).toBe(5));
+    });
+  });
+
+  describe('CATS units at a $10 table (v1.2 doc figures, exact)', () => {
+    const u = catsUnits(10);
+
+    it('gates: $70 / $150 / $250 / $400 (7u/15u/25u/40u)', () => {
+      expect(u.gates.littleMolly).toBe(70);
+      expect(u.gates.threePtMolly).toBe(150);
+      expect(u.gates.expandedAlpha).toBe(250);
+      expect(u.gates.maxAlpha).toBe(400);
+    });
+
+    it('flats and odds: $10 flat, $20 Little odds, $50 Loose odds', () => {
+      expect(u.flat).toBe(10);
+      expect(u.oddsLittle).toBe(20);
+      expect(u.oddsLoose).toBe(50);
+    });
+
+    it('tight tier: 30/20/10 sweet, 20/10/10 middle, 10/10/10 rough', () => {
+      expect(u.tier.sweet).toEqual({ passLine: 30, come1: 20, come2: 10 });
+      expect(u.tier.middle).toEqual({ passLine: 20, come1: 10, come2: 10 });
+      expect(u.tier.rough).toEqual({ passLine: 10, come1: 10, come2: 10 });
+    });
+
+    it('buys $20; accumulator $18 → $12; mode shift $200; risk $300; hard reset $20', () => {
+      expect(u.buyAmount).toBe(20);
+      expect(u.accumulatorStart).toBe(18);
+      expect(u.accumulatorRegressed).toBe(12);
+      expect(u.modeShiftCushion).toBe(200);
+      expect(u.classicRisk).toBe(300);
+      expect(u.hardReset).toBe(20);
+    });
+
+    it('reference funded configs (v4 §4): $200 @ Tight, $150 @ Little Molly', () => {
+      expect(u.referenceFunded.tight).toBe(200);
+      expect(u.referenceFunded.littleMolly).toBe(150);
+    });
+
+    it('stage loads: Little $60, Loose $180, Expanded $220, Max $260', () => {
+      expect(2 * u.flat + 2 * u.oddsLittle).toBe(60);
+      expect(3 * u.flat + 3 * u.oddsLoose).toBe(180);
+      expect(3 * u.flat + 3 * u.oddsLoose + 2 * u.buyAmount).toBe(220);
+      expect(3 * u.flat + 3 * u.oddsLoose + 4 * u.buyAmount).toBe(260);
+      expect(2 * u.accumulatorStart).toBe(36);
+      expect(2 * u.accumulatorRegressed).toBe(24);
+    });
+  });
+
+  describe('CATS units at a $15 table (v1.2 §3.1/§3.2 $15 columns, exact)', () => {
+    const u = catsUnits(15);
+
+    it('gates: $105 / $225 / $375 / $600', () => {
+      expect(u.gates.littleMolly).toBe(105);
+      expect(u.gates.threePtMolly).toBe(225);
+      expect(u.gates.expandedAlpha).toBe(375);
+      expect(u.gates.maxAlpha).toBe(600);
+    });
+
+    it('flats and odds: $15 flat, $30 Little odds, $75 Loose odds', () => {
+      expect(u.flat).toBe(15);
+      expect(u.oddsLittle).toBe(30);
+      expect(u.oddsLoose).toBe(75);
+    });
+
+    it('tight tier: 45/30/15 sweet', () => {
+      expect(u.tier.sweet).toEqual({ passLine: 45, come1: 30, come2: 15 });
+    });
+
+    it('buys $30; accumulator $24 → $18; risk $450', () => {
+      expect(u.buyAmount).toBe(30);
+      expect(u.accumulatorStart).toBe(24);
+      expect(u.accumulatorRegressed).toBe(18);
+      expect(u.classicRisk).toBe(450);
+    });
+
+    it('reference funded configs (v4 §4): $300 @ Tight, $225 @ Little Molly', () => {
+      expect(u.referenceFunded.tight).toBe(300);
+      expect(u.referenceFunded.littleMolly).toBe(225);
+    });
+
+    it('stage loads: Little $90, Loose $270, Expanded $330, Max $390', () => {
+      expect(2 * u.flat + 2 * u.oddsLittle).toBe(90);
+      expect(3 * u.flat + 3 * u.oddsLoose).toBe(270);
+      expect(3 * u.flat + 3 * u.oddsLoose + 2 * u.buyAmount).toBe(330);
+      expect(3 * u.flat + 3 * u.oddsLoose + 4 * u.buyAmount).toBe(390);
+      expect(2 * u.accumulatorStart).toBe(48);
+      expect(2 * u.accumulatorRegressed).toBe(36);
+    });
+  });
+
+  describe('BATS units', () => {
+    it('reproduces the v1.x $10 gate ladder exactly', () => {
+      const b = batsUnits(10);
+      expect(b.gates.littleDolly).toBe(120);
+      expect(b.gates.threePtDolly).toBe(225);
+      expect(b.gates.expandedDarkAlpha).toBe(350);
+      expect(b.gates.maxDarkAlpha).toBe(500);
+      expect(b.flat).toBe(10);
+      expect(b.layWinAccumulator).toBe(10);
+      expect(b.layWinDolly).toBe(20);
+      expect(b.layWinThreePt).toBe(50);
+      expect(b.layWinStandalone).toBe(20);
+    });
+
+    it('scales to $15 (gates rounded to the dollar)', () => {
+      const b = batsUnits(15);
+      expect(b.gates.littleDolly).toBe(180);
+      expect(b.gates.threePtDolly).toBe(338); // 22.5u rounded
+      expect(b.gates.expandedDarkAlpha).toBe(525);
+      expect(b.gates.maxDarkAlpha).toBe(750);
+      expect(b.layWinThreePt).toBe(75);
+    });
+  });
+
+  describe('CATS at $15 (engine smoke)', () => {
+    it('opens the Accumulator at $24 each on 6/8', () => {
+      const dice = new RiggedDice([4, 5]);
+      const engine = new CrapsEngine({ strategy: CATS({ tableMin: 15 }), bankroll: 450, rolls: 2, dice });
+      const result = engine.run();
+      const bets = result.rolls[0].activeBets;
+      expect(bets.find(b => b.type === 'place' && b.point === 6)!.amount).toBe(24);
+      expect(bets.find(b => b.type === 'place' && b.point === 8)!.amount).toBe(24);
+    });
+
+    it('runs 2000 rolls without throwing', () => {
+      const engine = new CrapsEngine({ strategy: CATS({ tableMin: 15 }), bankroll: 450, rolls: 2000, seed: 7 });
+      expect(() => engine.run()).not.toThrow();
+    });
+  });
+});

--- a/src/cli/analyze-stages.ts
+++ b/src/cli/analyze-stages.ts
@@ -27,6 +27,7 @@ import { CrapsEngine } from '../engine/craps-engine';
 import { StrategyDefinition } from '../dsl/strategy';
 import { createStrategy, getStageLadder, getStrategyMetadata } from './strategy-registry';
 import { parseStrategySpec } from './strategy-loader';
+import { buildManifest, RunManifest } from './manifest';
 import {
   StreamingStoppingEvaluator,
   StoppingConfig,
@@ -86,6 +87,8 @@ export interface AnalyzeReport {
   pctSessionsRuined: number;
   /** Stopping-rule menu results (v4 §3); present when sessions were scored. */
   stopping?: StoppingReport;
+  /** Run manifest (v4 §5) — embedded in every output mode. */
+  manifest?: RunManifest;
 }
 
 // Ladder display order; unknown stages append in encounter order.
@@ -341,6 +344,7 @@ function fmt(n: number, digits = 1): string {
 }
 
 function printText(report: AnalyzeReport): void {
+  if (report.manifest) console.log(`\nmanifest: ${JSON.stringify(report.manifest)}`);
   console.log(`\n=== Stage metrics (${report.sessions} sessions, up to ${report.rollsPerSession} rolls, $${report.bankroll} bankroll) ===\n`);
 
   const header =
@@ -481,6 +485,12 @@ export function runAnalysis(args: AnalyzeArgs): AnalyzeReport {
 
   const report = aggregate(sessions, { rollsPerSession: args.rolls, bankroll: args.bankroll });
   report.stopping = evaluator.report();
+  report.manifest = buildManifest({
+    strategySpec: args.strategy ?? `jsonl:${args.jsonlDir}`,
+    bankroll: args.bankroll,
+    rolls: args.rolls,
+    seeds: { count: args.jsonlDir ? sessions.length : args.seeds },
+  });
   return report;
 }
 
@@ -512,6 +522,9 @@ export function runComparison(args: AnalyzeArgs): CompareEntry[] {
 function printComparison(entries: CompareEntry[], args: AnalyzeArgs): void {
   const width = Math.max(24, ...entries.map(e => e.spec.length + 2));
   const label = (s: string) => s.padStart(width);
+  for (const e of entries) {
+    if (e.report.manifest) console.log(`manifest: ${JSON.stringify(e.report.manifest)}`);
+  }
   console.log(`\n=== Spec comparison (${args.seeds} shared seeds, up to ${args.rolls} rolls, $${args.bankroll} bankroll) ===\n`);
   console.log('Metric'.padEnd(30) + entries.map(e => label(e.spec)).join(''));
   console.log('-'.repeat(30 + width * entries.length));

--- a/src/cli/analyze-stages.ts
+++ b/src/cli/analyze-stages.ts
@@ -39,6 +39,8 @@ import {
 
 export interface AnalyzeArgs {
   strategy?: string;
+  /** Comparison mode: all specs, in flag order, when --strategy is repeated. */
+  strategies?: string[];
   jsonlDir?: string;
   rolls: number;
   bankroll: number;
@@ -101,6 +103,7 @@ const STAGE_ORDER = [
 export function parseArgs(argv: string[]): AnalyzeArgs {
   const single: Record<string, string> = {};
   const flags = new Set<string>();
+  const strategies: string[] = [];
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -113,13 +116,17 @@ export function parseArgs(argv: string[]): AnalyzeArgs {
       if (next === undefined || next.startsWith('--')) {
         throw new Error(`Flag --${key} requires a value.`);
       }
-      single[key] = next;
+      if (key === 'strategy') {
+        strategies.push(next); // repeatable: comparison mode when > 1
+      } else {
+        single[key] = next;
+      }
       i++;
     }
   }
 
-  if (!single['strategy'] && !single['jsonl-dir']) {
-    throw new Error('Provide --strategy <name> (to run sessions) or --jsonl-dir <path> (to analyze existing JSONL).');
+  if (strategies.length === 0 && !single['jsonl-dir']) {
+    throw new Error('Provide --strategy <spec> (repeatable, to run sessions) or --jsonl-dir <path> (to analyze existing JSONL).');
   }
 
   const output = single['output'] ?? 'text';
@@ -128,7 +135,8 @@ export function parseArgs(argv: string[]): AnalyzeArgs {
   }
 
   return {
-    strategy: single['strategy'],
+    strategy: strategies[0],
+    strategies: strategies.length > 0 ? strategies : undefined,
     jsonlDir: single['jsonl-dir'],
     rolls: parsePositiveInt(single['rolls'], 'rolls', 1000),
     bankroll: parsePositiveInt(single['bankroll'], 'bankroll', 300),
@@ -476,14 +484,105 @@ export function runAnalysis(args: AnalyzeArgs): AnalyzeReport {
   return report;
 }
 
+// ---------------------------------------------------------------------------
+// Multi-spec comparison (v4 §2: shared seeds, side-by-side)
+// ---------------------------------------------------------------------------
+
+export interface CompareEntry {
+  /** Canonical spec string. */
+  spec: string;
+  report: AnalyzeReport;
+}
+
+/**
+ * Run every spec over the SAME seed range (0..seeds-1) — identical dice per
+ * seed — and return reports in flag order. The canonical normalized spec
+ * string labels each column.
+ */
+export function runComparison(args: AnalyzeArgs): CompareEntry[] {
+  const entries: CompareEntry[] = [];
+  for (const spec of args.strategies!) {
+    const canonical = parseStrategySpec(spec).canonical;
+    const report = runAnalysis({ ...args, strategy: spec, strategies: undefined });
+    entries.push({ spec: canonical, report });
+  }
+  return entries;
+}
+
+function printComparison(entries: CompareEntry[], args: AnalyzeArgs): void {
+  const width = Math.max(24, ...entries.map(e => e.spec.length + 2));
+  const label = (s: string) => s.padStart(width);
+  console.log(`\n=== Spec comparison (${args.seeds} shared seeds, up to ${args.rolls} rolls, $${args.bankroll} bankroll) ===\n`);
+  console.log('Metric'.padEnd(30) + entries.map(e => label(e.spec)).join(''));
+  console.log('-'.repeat(30 + width * entries.length));
+
+  const row = (name: string, value: (e: CompareEntry) => string) =>
+    console.log(name.padEnd(30) + entries.map(e => label(value(e))).join(''));
+
+  row('P&L p10', e => money(e.report.pnl.p10));
+  row('P&L p50', e => money(e.report.pnl.p50));
+  row('P&L p90', e => money(e.report.pnl.p90));
+  row('Sessions positive %', e => fmt(e.report.pctSessionsPositive));
+  row('Sessions ruined %', e => fmt(e.report.pctSessionsRuined));
+
+  if (entries.every(e => e.report.stopping)) {
+    row('Peak P&L p50', e => money(e.report.stopping!.peakPnl.p50));
+    row('Peak P&L p90', e => money(e.report.stopping!.peakPnl.p90));
+    for (const h of entries[0].report.stopping!.hitting) {
+      row(`P(hit ${h.k}·B before ruin) %`, e => {
+        const hit = e.report.stopping!.hitting.find(x => x.k === h.k)!;
+        return fmt(100 * hit.pHitBeforeRuin);
+      });
+    }
+  }
+
+  // Stage-reach rows over the union of stages, first-seen order.
+  const stageOrder: string[] = [];
+  for (const e of entries) {
+    for (const s of e.report.stages) {
+      if (!stageOrder.includes(s.stage)) stageOrder.push(s.stage);
+    }
+  }
+  for (const stage of stageOrder) {
+    row(`reach % ${stage}`, e => {
+      const s = e.report.stages.find(x => x.stage === stage);
+      return s ? fmt(100 * s.reachProbability) : '—';
+    });
+  }
+
+  // Stopping-menu summary per spec: banked p50 and trigger rate per rule.
+  if (entries.every(e => e.report.stopping)) {
+    for (const rule of entries[0].report.stopping!.rules) {
+      row(`stop ${rule.rule} banked p50`, e => {
+        const r = e.report.stopping!.rules.find(x => x.rule === rule.rule);
+        return r ? money(r.banked.p50) : '—';
+      });
+      row(`stop ${rule.rule} trigger %`, e => {
+        const r = e.report.stopping!.rules.find(x => x.rule === rule.rule);
+        return r ? fmt(100 * r.triggerRate) : '—';
+      });
+    }
+  }
+  console.log('');
+}
+
 if (require.main === module) {
   try {
     const args = parseArgs(process.argv.slice(2));
-    const report = runAnalysis(args);
-    if (args.output === 'json') {
-      process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    if (args.strategies && args.strategies.length > 1) {
+      const entries = runComparison(args);
+      if (args.output === 'json') {
+        process.stdout.write(JSON.stringify(entries, null, 2) + '\n');
+      } else {
+        printComparison(entries, args);
+      }
     } else {
-      printText(report);
+      const report = runAnalysis(args);
+      if (args.output === 'json') {
+        process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+      } else {
+        printText(report);
+      }
     }
   } catch (err: any) {
     console.error(`Error: ${err.message}`);

--- a/src/cli/analyze-stages.ts
+++ b/src/cli/analyze-stages.ts
@@ -25,7 +25,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { CrapsEngine } from '../engine/craps-engine';
 import { StrategyDefinition } from '../dsl/strategy';
-import { createStrategy, lookupStrategy } from './strategy-registry';
+import { createStrategy } from './strategy-registry';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -140,7 +140,7 @@ function parsePositiveInt(raw: string | undefined, name: string, defaultValue: n
 // ---------------------------------------------------------------------------
 
 function runSessions(args: AnalyzeArgs): SessionView[] {
-  lookupStrategy(args.strategy!); // validate the name up front
+  createStrategy(args.strategy!); // validate the spec up front
   return runSessionsWithFactory(() => createStrategy(args.strategy!), args);
 }
 

--- a/src/cli/analyze-stages.ts
+++ b/src/cli/analyze-stages.ts
@@ -25,7 +25,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { CrapsEngine } from '../engine/craps-engine';
 import { StrategyDefinition } from '../dsl/strategy';
-import { createStrategy } from './strategy-registry';
+import { createStrategy, getStageLadder, getStrategyMetadata } from './strategy-registry';
+import { parseStrategySpec } from './strategy-loader';
+import {
+  StreamingStoppingEvaluator,
+  StoppingConfig,
+  StoppingReport,
+} from './stopping-rules';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -39,15 +45,19 @@ export interface AnalyzeArgs {
   seeds: number;
   stopAtRuin: boolean;
   output: 'text' | 'json';
+  /** Trailing-floor drop d in dollars (default bankroll / 3). */
+  trailDrop?: number;
+  /** Fall-below-stage rule slug (default: first gated stage of the ladder). */
+  belowStage?: string;
 }
 
 /** Minimal per-roll view the aggregator needs, from either source. */
-interface RollView {
+export interface RollView {
   stageName: string;
   equityAfter: number; // bankroll + table load, after settlement
 }
 
-interface SessionView {
+export interface SessionView {
   rolls: RollView[];
   initialBankroll: number;
   endedAtRuin: boolean;
@@ -72,6 +82,8 @@ export interface AnalyzeReport {
   pnl: { p10: number; p50: number; p90: number };
   pctSessionsPositive: number;
   pctSessionsRuined: number;
+  /** Stopping-rule menu results (v4 §3); present when sessions were scored. */
+  stopping?: StoppingReport;
 }
 
 // Ladder display order; unknown stages append in encounter order.
@@ -123,6 +135,8 @@ export function parseArgs(argv: string[]): AnalyzeArgs {
     seeds: parsePositiveInt(single['seeds'], 'seeds', 2000),
     stopAtRuin: flags.has('stop-at-ruin'),
     output,
+    trailDrop: single['trail-drop'] !== undefined ? parsePositiveInt(single['trail-drop'], 'trail-drop', 0) : undefined,
+    belowStage: single['exit-below-stage'],
   };
 }
 
@@ -139,15 +153,16 @@ function parsePositiveInt(raw: string | undefined, name: string, defaultValue: n
 // Session sources
 // ---------------------------------------------------------------------------
 
-function runSessions(args: AnalyzeArgs): SessionView[] {
+function runSessions(args: AnalyzeArgs, onSession?: (s: SessionView) => void): SessionView[] {
   createStrategy(args.strategy!); // validate the spec up front
-  return runSessionsWithFactory(() => createStrategy(args.strategy!), args);
+  return runSessionsWithFactory(() => createStrategy(args.strategy!), args, onSession);
 }
 
 /** Run seeded sessions for any strategy factory and return session views. */
 export function runSessionsWithFactory(
   factory: () => StrategyDefinition,
   args: Pick<AnalyzeArgs, 'rolls' | 'bankroll' | 'seeds' | 'stopAtRuin'>,
+  onSession?: (s: SessionView) => void,
 ): SessionView[] {
   const sessions: SessionView[] = [];
   for (let seed = 0; seed < args.seeds; seed++) {
@@ -160,14 +175,16 @@ export function runSessionsWithFactory(
       stopAtRuin: args.stopAtRuin,
     });
     const result = engine.run();
-    sessions.push({
+    const view: SessionView = {
       initialBankroll: result.initialBankroll,
       endedAtRuin: result.endedAtRuin ?? false,
       rolls: result.rolls.map(r => ({
         stageName: r.stagePlayed ?? r.stageName ?? '(stageless)',
         equityAfter: r.bankrollAfter + r.tableLoadAfter,
       })),
-    });
+    };
+    if (onSession) onSession(view); // streaming consumers score per session
+    sessions.push(view);
   }
   return sessions;
 }
@@ -182,7 +199,7 @@ export function analyzeWithFactory(
 }
 
 /** Parse run-sim --output json JSONL files (one session per file). */
-function loadJsonlSessions(dir: string): SessionView[] {
+function loadJsonlSessions(dir: string, onSession?: (s: SessionView) => void): SessionView[] {
   const files = fs.readdirSync(dir).filter(f => f.endsWith('.jsonl')).sort();
   if (files.length === 0) {
     throw new Error(`No .jsonl files found in ${dir}`);
@@ -210,13 +227,15 @@ function loadJsonlSessions(dir: string): SessionView[] {
     }
     if (rolls.length === 0) continue;
     const finalEquity = rolls[rolls.length - 1].equityAfter;
-    sessions.push({
+    const view: SessionView = {
       rolls,
       initialBankroll: initialBankroll ?? 0,
       // JSONL carries no explicit ruin marker: treat a session whose final
       // equity cannot fund a $10 flat bet as ruined.
       endedAtRuin: sawBets && finalEquity < 10,
-    });
+    };
+    if (onSession) onSession(view);
+    sessions.push(view);
   }
   return sessions;
 }
@@ -339,6 +358,43 @@ function printText(report: AnalyzeReport): void {
   console.log(`\nSession P&L: p10 ${money(report.pnl.p10)}  p50 ${money(report.pnl.p50)}  p90 ${money(report.pnl.p90)}`);
   console.log(`Sessions ending positive: ${fmt(report.pctSessionsPositive)}%`);
   console.log(`Sessions ending at ruin:  ${fmt(report.pctSessionsRuined)}%\n`);
+
+  if (report.stopping) printStopping(report.stopping);
+}
+
+function printStopping(stopping: StoppingReport): void {
+  console.log('=== Stopping-rule menu (banked P&L per rule; sessions play fully out) ===\n');
+  const header =
+    'Rule'.padEnd(14) +
+    ' | ' + 'Trigger %'.padStart(9) +
+    ' | ' + 'Ruin %'.padStart(7) +
+    ' | ' + 'Cens. %'.padStart(7) +
+    ' | ' + 'p10'.padStart(7) +
+    ' | ' + 'p50'.padStart(7) +
+    ' | ' + 'p90'.padStart(7) +
+    ' | ' + 'Pos %'.padStart(6) +
+    ' | ' + 'PeakCap'.padStart(7);
+  console.log(header);
+  console.log('-'.repeat(header.length));
+  for (const r of stopping.rules) {
+    console.log(
+      r.rule.padEnd(14) +
+      ' | ' + fmt(100 * r.triggerRate).padStart(9) +
+      ' | ' + fmt(100 * r.ruinRate).padStart(7) +
+      ' | ' + fmt(100 * r.censoredRate).padStart(7) +
+      ' | ' + money(r.banked.p10).padStart(7) +
+      ' | ' + money(r.banked.p50).padStart(7) +
+      ' | ' + money(r.banked.p90).padStart(7) +
+      ' | ' + fmt(r.pctPositive).padStart(6) +
+      ' | ' + (r.peakCapture === null ? '—' : r.peakCapture.toFixed(2)).padStart(7)
+    );
+  }
+  const peaks = stopping.peakPnl;
+  console.log(`\nPeak P&L: p10 ${money(peaks.p10)}  p25 ${money(peaks.p25)}  p50 ${money(peaks.p50)}  p75 ${money(peaks.p75)}  p90 ${money(peaks.p90)}  p99 ${money(peaks.p99)}`);
+  const hits = stopping.hitting
+    .map(h => `k=${h.k}: ${fmt(100 * h.pHitBeforeRuin)}% (censored ${fmt(100 * h.censoredFraction)}%)`)
+    .join('   ');
+  console.log(`P(hit k·B before ruin): ${hits}\n`);
 }
 
 function money(n: number): string {
@@ -350,11 +406,74 @@ function money(n: number): string {
 // Entry point
 // ---------------------------------------------------------------------------
 
+/**
+ * Build the stopping config for a spec: trailing-floor drop, and the
+ * fall-below-stage ladder level (default: the ladder's first gated stage).
+ * Returns the config plus the state → ladder-level map used to score rolls.
+ */
+export function buildStoppingContext(
+  args: Pick<AnalyzeArgs, 'strategy' | 'bankroll' | 'trailDrop' | 'belowStage'>,
+): { config: StoppingConfig; stateLevel: Map<string, number> | null } {
+  const config: StoppingConfig = {
+    bankroll: args.bankroll,
+    ...(args.trailDrop !== undefined ? { trailDrop: args.trailDrop } : {}),
+  };
+  let stateLevel: Map<string, number> | null = null;
+
+  if (args.strategy) {
+    const ladder = getStageLadder(args.strategy);
+    if (ladder) {
+      stateLevel = new Map(ladder.stateOrder.map((state, i) => [state, i]));
+      let slug = args.belowStage;
+      if (slug === undefined) {
+        const meta = getStrategyMetadata(parseStrategySpec(args.strategy).name);
+        slug = meta.stages.find(m => m.gate > 0)?.slug;
+      }
+      if (slug !== undefined) {
+        const state = ladder.slugToState.get(slug);
+        if (state === undefined) {
+          const valid = [...ladder.slugToState.keys()].join(', ');
+          throw new Error(`Unknown --exit-below-stage slug "${slug}". Valid slugs: ${valid}`);
+        }
+        config.belowStageLevel = stateLevel.get(state);
+        config.belowStageSlug = slug;
+      }
+    }
+  }
+  return { config, stateLevel };
+}
+
+/** Feed one materialized session through the streaming evaluator. */
+export function streamSession(
+  evaluator: StreamingStoppingEvaluator,
+  session: SessionView,
+  stateLevel: Map<string, number> | null,
+): void {
+  evaluator.beginSession();
+  let finalEquity = session.initialBankroll;
+  for (const roll of session.rolls) {
+    const level = stateLevel ? stateLevel.get(roll.stageName) : undefined;
+    evaluator.onRoll(roll.equityAfter, level);
+    finalEquity = roll.equityAfter;
+  }
+  evaluator.endSession(finalEquity, session.endedAtRuin);
+}
+
 export function runAnalysis(args: AnalyzeArgs): AnalyzeReport {
+  const { config, stateLevel } = buildStoppingContext(args);
+  const evaluator = new StreamingStoppingEvaluator(config);
+
+  // The streaming path: each session is scored roll-by-roll as it is
+  // produced (one pass; sessions still play fully out).
+  const onSession = (session: SessionView) => streamSession(evaluator, session, stateLevel);
+
   const sessions = args.jsonlDir
-    ? loadJsonlSessions(args.jsonlDir)
-    : runSessions(args);
-  return aggregate(sessions, { rollsPerSession: args.rolls, bankroll: args.bankroll });
+    ? loadJsonlSessions(args.jsonlDir, onSession)
+    : runSessions(args, onSession);
+
+  const report = aggregate(sessions, { rollsPerSession: args.rolls, bankroll: args.bankroll });
+  report.stopping = evaluator.report();
+  return report;
 }
 
 if (require.main === module) {
@@ -369,7 +488,7 @@ if (require.main === module) {
   } catch (err: any) {
     console.error(`Error: ${err.message}`);
     console.error('Usage:');
-    console.error('  npx ts-node src/cli/analyze-stages.ts --strategy CATS --rolls 1000 --bankroll 300 --seeds 2000 [--stop-at-ruin] [--output text|json]');
+    console.error('  npx ts-node src/cli/analyze-stages.ts --strategy CATS[@entry=slug,tableMin=n] --rolls 1000 --bankroll 300 --seeds 2000 [--stop-at-ruin] [--trail-drop n] [--exit-below-stage slug] [--output text|json]');
     console.error('  npx ts-node src/cli/analyze-stages.ts --jsonl-dir ./sessions [--output json]');
     process.exit(1);
   }

--- a/src/cli/manifest.ts
+++ b/src/cli/manifest.ts
@@ -1,0 +1,92 @@
+/**
+ * Run manifest — session-lifecycle.md v4 §5.
+ *
+ * Determinism makes the manifest the archive: a run is fully reproducible
+ * from { strategySpec, tableMin, bankroll, rolls, seeds, engineVersion }.
+ * The manifest is embedded in every output mode; aggregate results are
+ * memoized keyed by a stable hash of the manifest minus generatedAt.
+ */
+import { execSync } from 'child_process';
+import { createHash } from 'crypto';
+import { parseStrategySpec } from './strategy-loader';
+
+export const MANIFEST_SCHEMA_VERSION = 1;
+
+export interface RunManifest {
+  schemaVersion: number;
+  /** Canonical strategy spec (NAME[@key=value,...]), or a source tag for JSONL re-analysis. */
+  strategySpec: string;
+  tableMin: number;
+  bankroll: number;
+  rolls: number;
+  /** Seed range { count } (seeds 0..count-1) or a single { seed }. */
+  seeds: { count: number } | { seed: number | null };
+  /** Engine git sha (short). Falls back to ENGINE_VERSION env, then "unknown". */
+  engineVersion: string;
+  /** Wall-clock stamp — excluded from the identity hash. */
+  generatedAt: string;
+}
+
+let cachedEngineVersion: string | null = null;
+
+export function engineVersion(): string {
+  if (cachedEngineVersion === null) {
+    try {
+      cachedEngineVersion = execSync('git rev-parse --short HEAD', {
+        cwd: __dirname,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).toString().trim();
+    } catch {
+      cachedEngineVersion = process.env.ENGINE_VERSION ?? 'unknown';
+    }
+  }
+  return cachedEngineVersion;
+}
+
+export interface ManifestInputs {
+  /** Strategy spec string; canonicalized here. Pass a `jsonl:` tag for re-analysis runs. */
+  strategySpec: string;
+  bankroll: number;
+  rolls: number;
+  seeds: { count: number } | { seed: number | null };
+  /** Override table minimum; defaults to the spec's tableMin option or $10. */
+  tableMin?: number;
+}
+
+export function buildManifest(inputs: ManifestInputs): RunManifest {
+  let tableMin = inputs.tableMin;
+  let spec = inputs.strategySpec;
+  if (!spec.startsWith('jsonl:')) {
+    try {
+      const parsed = parseStrategySpec(spec);
+      spec = parsed.canonical;
+      tableMin = tableMin ?? parsed.options.tableMin;
+    } catch {
+      // Strategy-file paths and other non-registry sources pass through as-is.
+    }
+  }
+  return {
+    schemaVersion: MANIFEST_SCHEMA_VERSION,
+    strategySpec: spec,
+    tableMin: tableMin ?? 10,
+    bankroll: inputs.bankroll,
+    rolls: inputs.rolls,
+    seeds: inputs.seeds,
+    engineVersion: engineVersion(),
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+/** Recursively key-sorted JSON — a stable serialization for hashing. */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const keys = Object.keys(value as object).sort();
+  return `{${keys.map(k => `${JSON.stringify(k)}:${stableStringify((value as any)[k])}`).join(',')}}`;
+}
+
+/** Stable identity hash of a manifest, excluding generatedAt. */
+export function manifestHash(manifest: RunManifest): string {
+  const { generatedAt: _ignored, ...identity } = manifest;
+  return createHash('sha256').update(stableStringify(identity)).digest('hex');
+}

--- a/src/cli/run-sim.ts
+++ b/src/cli/run-sim.ts
@@ -24,6 +24,7 @@ import { RunLogger } from '../logger/run-logger';
 import { StrategyDefinition } from '../dsl/strategy';
 import { lookupStrategy, createStrategy } from './strategy-registry';
 import { loadStrategyFile } from './strategy-loader';
+import { buildManifest, RunManifest } from './manifest';
 import { summarize, computeFullAggregates } from '../../server/lib/distribution';
 
 // ---------------------------------------------------------------------------
@@ -196,7 +197,24 @@ export function runSim(args: CliArgs): void {
   });
 
   engine.run();
+  const manifest = buildManifest({
+    strategySpec: strategyName,
+    bankroll: args.bankroll,
+    rolls: args.rolls,
+    seeds: { seed: args.seed ?? null },
+  });
+  emitManifest(manifest, args.output as 'summary' | 'verbose' | 'json');
   logger.flush(args.output as 'summary' | 'verbose' | 'json');
+}
+
+/** Embed the run manifest in every output mode (v4 §5). */
+function emitManifest(manifest: RunManifest | RunManifest[], output: 'summary' | 'verbose' | 'json'): void {
+  const list = Array.isArray(manifest) ? manifest : [manifest];
+  if (output === 'json') {
+    for (const m of list) console.log(JSON.stringify({ type: 'manifest', manifest: m }));
+  } else {
+    for (const m of list) console.log(`manifest: ${JSON.stringify(m)}`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -238,7 +256,13 @@ export function runDistribution(args: CliArgs): void {
     bankroll: args.bankroll,
   });
 
-  process.stdout.write(JSON.stringify(aggregates, null, 2) + '\n');
+  const manifest = buildManifest({
+    strategySpec: strategyName,
+    bankroll: args.bankroll,
+    rolls: args.rolls,
+    seeds: { count: N },
+  });
+  process.stdout.write(JSON.stringify({ manifest, ...aggregates }, null, 2) + '\n');
 }
 
 // ---------------------------------------------------------------------------
@@ -266,6 +290,14 @@ export function runCompare(args: CliArgs): void {
   }
 
   const results = table.run();
+
+  const manifests = strategies.map(({ name }) => buildManifest({
+    strategySpec: name,
+    bankroll: args.bankroll,
+    rolls: args.rolls,
+    seeds: { seed: args.seed ?? null },
+  }));
+  emitManifest(manifests, args.output === 'json' ? 'json' : 'summary');
 
   if (args.output === 'json') {
     printComparisonJson(results);

--- a/src/cli/run-sim.ts
+++ b/src/cli/run-sim.ts
@@ -177,7 +177,7 @@ export function runSim(args: CliArgs): void {
     strategyName = args.strategyFile;
   } else {
     strategyName = args.strategy!;
-    strategy = lookupStrategy(strategyName);
+    strategy = createStrategy(strategyName); // spec-aware: NAME[@key=value,...]
   }
 
   const logger = new RunLogger({
@@ -210,7 +210,7 @@ export function runDistribution(args: CliArgs): void {
     strategyName = args.strategyFile;
   } else {
     strategyName = args.strategy!;
-    lookupStrategy(strategyName); // validate the name up front
+    createStrategy(strategyName); // validate the spec up front
   }
 
   const N = args.seeds!;
@@ -249,7 +249,7 @@ export function runCompare(args: CliArgs): void {
   const strategies: Array<{ name: string; strategy: StrategyDefinition }> = [];
 
   for (const name of args.compare ?? []) {
-    strategies.push({ name, strategy: lookupStrategy(name) });
+    strategies.push({ name, strategy: createStrategy(name) });
   }
 
   for (const filePath of args.compareFiles ?? []) {

--- a/src/cli/stopping-rules.ts
+++ b/src/cli/stopping-rules.ts
@@ -1,0 +1,345 @@
+/**
+ * Stopping-rule evaluator — session-lifecycle.md v4 §3.
+ *
+ * Exit rules are stopping times, so the whole standard menu is scored in one
+ * pass while sessions play fully out: each rule tracks its trigger state per
+ * roll; when it fires, its banked P&L is recorded and the session continues
+ * for the remaining rules and the played-fully-out baseline.
+ *
+ * Standard menu: none (baseline), hard targets at equity ≥ k·B for
+ * k ∈ {2,3,6}, trailing floor (exit when equity ≤ peak − d, default d = B/3),
+ * fall-below-stage (configurable slug), and roll caps {100, 200, 300}.
+ *
+ * Two independent implementations live here on purpose:
+ *   - StreamingStoppingEvaluator: incremental per-roll state (the production
+ *     path, run during simulation).
+ *   - evaluateStoppingPostHoc: whole-trajectory truncation scans (the
+ *     validation path, run over archived JSONL trajectories).
+ * The dual-path gate asserts their outputs are exactly equal.
+ */
+
+export interface StoppingConfig {
+  bankroll: number;
+  /** Trailing-floor drop d in dollars (default: bankroll / 3, rounded). */
+  trailDrop?: number;
+  /**
+   * Fall-below-stage rule: ladder level (index into the machine's state
+   * order) below which the rule fires, once the session has been at or
+   * above it. Omit to skip the rule (non-staged strategies / no ladder).
+   */
+  belowStageLevel?: number;
+  /** Slug used only for labeling the fall-below-stage rule. */
+  belowStageSlug?: string;
+}
+
+/** One session's trajectory as the evaluator consumes it. */
+export interface TrajectoryView {
+  /** equityAfter per roll (rack + felt, post-settlement). */
+  equity: number[];
+  /** Ladder level of stagePlayed per roll (parallel to equity); optional. */
+  stageLevel?: number[];
+  endedAtRuin: boolean;
+}
+
+export type StopOutcome = 'triggered' | 'ruin' | 'censored';
+
+export interface RuleSessionResult {
+  outcome: StopOutcome;
+  /** Banked P&L: equity at exit (or final equity) − bankroll. */
+  banked: number;
+  /** Roll index (1-based) at which the rule fired; null if it never did. */
+  exitRoll: number | null;
+}
+
+export interface StoppingRuleReport {
+  rule: string;
+  params?: Record<string, number | string>;
+  triggerRate: number;
+  ruinRate: number;
+  censoredRate: number;
+  banked: { p10: number; p50: number; p90: number };
+  pctPositive: number;
+  /**
+   * Peak-capture ratio over sessions whose peak P&L is positive, computed
+   * as ratio of sums: Σ(exit P&L) ÷ Σ(peak P&L). (Ratio-of-sums rather than
+   * mean-of-ratios — near-zero peaks make per-session ratios explode.)
+   * Null when no session had a positive peak.
+   */
+  peakCapture: number | null;
+}
+
+export interface StoppingReport {
+  rules: StoppingRuleReport[];
+  /** P(equity reached k·B before ruin), with the censored fraction stated. */
+  hitting: { k: number; pHitBeforeRuin: number; censoredFraction: number }[];
+  /** Peak session P&L distribution — a first-class output (v4 §3). */
+  peakPnl: { p10: number; p25: number; p50: number; p75: number; p90: number; p99: number };
+}
+
+export const TARGET_KS = [2, 3, 6];
+export const ROLL_CAPS = [100, 200, 300];
+
+interface RuleDef {
+  id: string;
+  params?: Record<string, number | string>;
+}
+
+export function ruleDefs(config: StoppingConfig): RuleDef[] {
+  const d = config.trailDrop ?? Math.round(config.bankroll / 3);
+  const defs: RuleDef[] = [{ id: 'none' }];
+  for (const k of TARGET_KS) defs.push({ id: `target-${k}x`, params: { k } });
+  defs.push({ id: 'trail', params: { drop: d } });
+  if (config.belowStageLevel !== undefined) {
+    defs.push({ id: 'below-stage', params: { slug: config.belowStageSlug ?? String(config.belowStageLevel) } });
+  }
+  for (const cap of ROLL_CAPS) defs.push({ id: `cap-${cap}`, params: { rolls: cap } });
+  return defs;
+}
+
+// ---------------------------------------------------------------------------
+// Path 1: streaming (incremental per-roll state)
+// ---------------------------------------------------------------------------
+
+interface StreamRuleState {
+  exitRoll: number | null;
+  banked: number | null;
+  armed: boolean; // below-stage only
+}
+
+export class StreamingStoppingEvaluator {
+  private readonly config: StoppingConfig;
+  private readonly trailDrop: number;
+  private readonly defs: RuleDef[];
+
+  // Per-session working state
+  private states: Map<string, StreamRuleState> = new Map();
+  private peak = 0;
+  private rollIndex = 0;
+  private hitK: Map<number, boolean> = new Map();
+
+  // Accumulated per-session results
+  private perRule: Map<string, RuleSessionResult[]> = new Map();
+  private peaks: number[] = [];
+  private hitting: Map<number, { hit: number; ruined: number; censored: number }> = new Map();
+
+  constructor(config: StoppingConfig) {
+    this.config = config;
+    this.trailDrop = config.trailDrop ?? Math.round(config.bankroll / 3);
+    this.defs = ruleDefs(config);
+    for (const def of this.defs) this.perRule.set(def.id, []);
+    for (const k of TARGET_KS) this.hitting.set(k, { hit: 0, ruined: 0, censored: 0 });
+  }
+
+  beginSession(): void {
+    this.states = new Map(this.defs.map(d => [d.id, { exitRoll: null, banked: null, armed: false }]));
+    this.peak = this.config.bankroll;
+    this.rollIndex = 0;
+    this.hitK = new Map(TARGET_KS.map(k => [k, false]));
+  }
+
+  onRoll(equityAfter: number, stageLevel?: number): void {
+    this.rollIndex++;
+    const B = this.config.bankroll;
+    if (equityAfter > this.peak) this.peak = equityAfter;
+
+    for (const k of TARGET_KS) {
+      if (!this.hitK.get(k) && equityAfter >= k * B) this.hitK.set(k, true);
+    }
+
+    for (const def of this.defs) {
+      const st = this.states.get(def.id)!;
+      if (st.exitRoll !== null) continue;
+
+      let fire = false;
+      if (def.id.startsWith('target-')) {
+        fire = equityAfter >= (def.params!.k as number) * B;
+      } else if (def.id === 'trail') {
+        fire = equityAfter <= this.peak - this.trailDrop;
+      } else if (def.id === 'below-stage') {
+        const level = stageLevel;
+        if (level !== undefined && this.config.belowStageLevel !== undefined) {
+          if (level >= this.config.belowStageLevel) st.armed = true;
+          else if (st.armed) fire = true;
+        }
+      } else if (def.id.startsWith('cap-')) {
+        fire = this.rollIndex >= (def.params!.rolls as number);
+      }
+      // 'none' never fires.
+
+      if (fire) {
+        st.exitRoll = this.rollIndex;
+        st.banked = equityAfter - B;
+      }
+    }
+  }
+
+  endSession(finalEquity: number, endedAtRuin: boolean): void {
+    const B = this.config.bankroll;
+    const finalPnl = finalEquity - B;
+    for (const def of this.defs) {
+      const st = this.states.get(def.id)!;
+      const result: RuleSessionResult = st.exitRoll !== null
+        ? { outcome: 'triggered', banked: st.banked!, exitRoll: st.exitRoll }
+        : { outcome: endedAtRuin ? 'ruin' : 'censored', banked: finalPnl, exitRoll: null };
+      this.perRule.get(def.id)!.push(result);
+    }
+    this.peaks.push(this.peak - B);
+    for (const k of TARGET_KS) {
+      const bucket = this.hitting.get(k)!;
+      if (this.hitK.get(k)) bucket.hit++;
+      else if (endedAtRuin) bucket.ruined++;
+      else bucket.censored++;
+    }
+  }
+
+  report(): StoppingReport {
+    return buildReport(this.defs, this.perRule, this.peaks, this.hitting);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Path 2: post-hoc truncation (independent implementation for validation)
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate the same menu by literal truncation of full trajectories:
+ * for each rule, scan the whole equity path for the first roll satisfying
+ * the rule, truncate there, and bank that equity. Implemented with
+ * whole-array scans (not incremental state) so it validates the streaming
+ * path rather than mirroring it.
+ */
+export function evaluateStoppingPostHoc(trajectories: TrajectoryView[], config: StoppingConfig): StoppingReport {
+  const B = config.bankroll;
+  const trailDrop = config.trailDrop ?? Math.round(B / 3);
+  const defs = ruleDefs(config);
+  const perRule = new Map<string, RuleSessionResult[]>(defs.map(d => [d.id, []]));
+  const peaks: number[] = [];
+  const hitting = new Map<number, { hit: number; ruined: number; censored: number }>(
+    TARGET_KS.map(k => [k, { hit: 0, ruined: 0, censored: 0 }]),
+  );
+
+  for (const t of trajectories) {
+    const eq = t.equity;
+    const n = eq.length;
+    const finalPnl = (n > 0 ? eq[n - 1] : B) - B;
+
+    // Running peak (prefix max including the starting bankroll).
+    const prefixPeak: number[] = new Array(n);
+    let p = B;
+    for (let i = 0; i < n; i++) {
+      p = Math.max(p, eq[i]);
+      prefixPeak[i] = p;
+    }
+    peaks.push((n > 0 ? prefixPeak[n - 1] : B) - B);
+
+    for (const k of TARGET_KS) {
+      const hitIdx = eq.findIndex(e => e >= k * B);
+      const bucket = hitting.get(k)!;
+      if (hitIdx !== -1) bucket.hit++;
+      else if (t.endedAtRuin) bucket.ruined++;
+      else bucket.censored++;
+    }
+
+    for (const def of defs) {
+      let idx = -1;
+      if (def.id.startsWith('target-')) {
+        const k = def.params!.k as number;
+        idx = eq.findIndex(e => e >= k * B);
+      } else if (def.id === 'trail') {
+        idx = eq.findIndex((e, i) => e <= prefixPeak[i] - trailDrop);
+      } else if (def.id === 'below-stage') {
+        const levels = t.stageLevel;
+        if (levels && config.belowStageLevel !== undefined) {
+          let armedAt = -1;
+          for (let i = 0; i < n; i++) {
+            if (levels[i] >= config.belowStageLevel) { armedAt = i; break; }
+          }
+          if (armedAt !== -1) {
+            for (let i = armedAt; i < n; i++) {
+              if (levels[i] < config.belowStageLevel) { idx = i; break; }
+            }
+          }
+        }
+      } else if (def.id.startsWith('cap-')) {
+        const cap = def.params!.rolls as number;
+        idx = n >= cap ? cap - 1 : -1;
+      }
+
+      const results = perRule.get(def.id)!;
+      if (idx !== -1) {
+        results.push({ outcome: 'triggered', banked: eq[idx] - B, exitRoll: idx + 1 });
+      } else {
+        results.push({ outcome: t.endedAtRuin ? 'ruin' : 'censored', banked: finalPnl, exitRoll: null });
+      }
+    }
+  }
+
+  return buildReport(defs, perRule, peaks, hitting);
+}
+
+// ---------------------------------------------------------------------------
+// Shared aggregation
+// ---------------------------------------------------------------------------
+
+function quantile(sorted: number[], q: number): number {
+  if (sorted.length === 0) return NaN;
+  const idx = (sorted.length - 1) * q;
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+function buildReport(
+  defs: RuleDef[],
+  perRule: Map<string, RuleSessionResult[]>,
+  peaks: number[],
+  hitting: Map<number, { hit: number; ruined: number; censored: number }>,
+): StoppingReport {
+  const rules: StoppingRuleReport[] = defs.map(def => {
+    const results = perRule.get(def.id)!;
+    const n = results.length || 1;
+    const banked = results.map(r => r.banked).sort((a, b) => a - b);
+    // Peak capture: Σ(exit P&L) ÷ Σ(peak P&L) over peak-positive paths.
+    let exitSum = 0;
+    let peakSum = 0;
+    results.forEach((r, i) => {
+      if (peaks[i] > 0) {
+        exitSum += r.banked;
+        peakSum += peaks[i];
+      }
+    });
+    return {
+      rule: def.id,
+      ...(def.params ? { params: def.params } : {}),
+      triggerRate: results.filter(r => r.outcome === 'triggered').length / n,
+      ruinRate: results.filter(r => r.outcome === 'ruin').length / n,
+      censoredRate: results.filter(r => r.outcome === 'censored').length / n,
+      banked: { p10: quantile(banked, 0.1), p50: quantile(banked, 0.5), p90: quantile(banked, 0.9) },
+      pctPositive: (100 * results.filter(r => r.banked > 0).length) / n,
+      peakCapture: peakSum > 0 ? exitSum / peakSum : null,
+    };
+  });
+
+  const sortedPeaks = peaks.slice().sort((a, b) => a - b);
+  const sessions = peaks.length || 1;
+  return {
+    rules,
+    hitting: TARGET_KS.map(k => {
+      const b = hitting.get(k)!;
+      return {
+        k,
+        pHitBeforeRuin: b.hit / sessions,
+        censoredFraction: b.censored / sessions,
+      };
+    }),
+    peakPnl: {
+      p10: quantile(sortedPeaks, 0.1),
+      p25: quantile(sortedPeaks, 0.25),
+      p50: quantile(sortedPeaks, 0.5),
+      p75: quantile(sortedPeaks, 0.75),
+      p90: quantile(sortedPeaks, 0.9),
+      p99: quantile(sortedPeaks, 0.99),
+    },
+  };
+}

--- a/src/cli/strategy-loader.ts
+++ b/src/cli/strategy-loader.ts
@@ -1,6 +1,95 @@
 import * as path from 'path';
 import { StrategyDefinition } from '../dsl/strategy';
 
+// ---------------------------------------------------------------------------
+// Canonical strategy specs — NAME@key=value[,key=value]
+// (session-lifecycle.md v4 §2: `CATS@entry=threePtMollyLoose`)
+// ---------------------------------------------------------------------------
+
+/** Options a strategy spec can carry. */
+export interface StrategySpecOptions {
+  /** Funded-entry stage slug (resolved by the strategy's stage metadata). */
+  entry?: string;
+  /** Table minimum in dollars. */
+  tableMin?: number;
+}
+
+export interface ParsedStrategySpec {
+  /** Registry name (e.g. "CATS"). */
+  name: string;
+  options: StrategySpecOptions;
+  /**
+   * Normalized canonical form: bare name when no options; otherwise
+   * NAME@key=value[,key=value] with keys in canonical order (entry,
+   * tableMin). This string is the manifest's `strategySpec` — parsing it
+   * again yields the same canonical string (round-trip stable).
+   */
+  canonical: string;
+}
+
+const SPEC_KEYS = ['entry', 'tableMin'] as const;
+
+/**
+ * Parse a canonical strategy spec. Throws with the valid key list on
+ * unknown keys and on malformed input; entry-slug validity is checked by
+ * the strategy factory itself (which knows its stage metadata).
+ */
+export function parseStrategySpec(spec: string): ParsedStrategySpec {
+  const at = spec.indexOf('@');
+  const name = (at === -1 ? spec : spec.slice(0, at)).trim();
+  if (!name) {
+    throw new Error(`Invalid strategy spec "${spec}": empty strategy name.`);
+  }
+
+  const options: StrategySpecOptions = {};
+  if (at !== -1) {
+    const optString = spec.slice(at + 1);
+    if (!optString) {
+      throw new Error(`Invalid strategy spec "${spec}": "@" with no options.`);
+    }
+    for (const pair of optString.split(',')) {
+      const eq = pair.indexOf('=');
+      if (eq === -1) {
+        throw new Error(`Invalid strategy spec "${spec}": option "${pair}" is not key=value.`);
+      }
+      const key = pair.slice(0, eq).trim();
+      const value = pair.slice(eq + 1).trim();
+      if (!value) {
+        throw new Error(`Invalid strategy spec "${spec}": option "${key}" has no value.`);
+      }
+      switch (key) {
+        case 'entry':
+          if (options.entry !== undefined) throw new Error(`Invalid strategy spec "${spec}": duplicate key "entry".`);
+          options.entry = value;
+          break;
+        case 'tableMin': {
+          if (options.tableMin !== undefined) throw new Error(`Invalid strategy spec "${spec}": duplicate key "tableMin".`);
+          const n = Number(value);
+          if (!Number.isInteger(n) || n <= 0) {
+            throw new Error(`Invalid strategy spec "${spec}": tableMin must be a positive integer, got "${value}".`);
+          }
+          options.tableMin = n;
+          break;
+        }
+        default:
+          throw new Error(
+            `Invalid strategy spec "${spec}": unknown option "${key}". Valid options: ${SPEC_KEYS.join(', ')}.`
+          );
+      }
+    }
+  }
+
+  return { name, options, canonical: canonicalizeSpec(name, options) };
+}
+
+/** Render the canonical string form of a name + options. */
+export function canonicalizeSpec(name: string, options: StrategySpecOptions): string {
+  const parts: string[] = [];
+  if (options.entry !== undefined) parts.push(`entry=${options.entry}`);
+  if (options.tableMin !== undefined) parts.push(`tableMin=${options.tableMin}`);
+  return parts.length === 0 ? name : `${name}@${parts.join(',')}`;
+}
+
 /**
  * Dynamically load a user-supplied `.ts` strategy file.
  *

--- a/src/cli/strategy-registry.ts
+++ b/src/cli/strategy-registry.ts
@@ -182,3 +182,18 @@ export function getStrategyMetadata(name: string): StrategyMetadata {
 export function listStrategyNames(): string[] {
   return Object.keys(BUILT_IN_STRATEGIES);
 }
+
+/**
+ * Ladder info for stopping rules: machine states in ladder order plus the
+ * slug → state mapping. Returns null for non-staged strategies.
+ */
+export function getStageLadder(spec: string): { stateOrder: string[]; slugToState: Map<string, string> } | null {
+  const instance = createStrategy(spec);
+  const runtime = (instance as any)[STAGE_MACHINE_RUNTIME] as StageMachineRuntime | undefined;
+  if (!runtime) return null;
+  const slugToState = new Map<string, string>();
+  for (const row of runtime.getStageMetadata()) {
+    slugToState.set(row.slug, row.state);
+  }
+  return { stateOrder: runtime.getStateOrder(), slugToState };
+}

--- a/src/cli/strategy-registry.ts
+++ b/src/cli/strategy-registry.ts
@@ -1,4 +1,7 @@
-import { StrategyDefinition } from '../dsl/strategy';
+import { StrategyDefinition, STAGE_MACHINE_RUNTIME } from '../dsl/strategy';
+import { StageMachineRuntime } from '../dsl/stage-machine-state';
+import { StageMetadata } from '../dsl/stage-machine-types';
+import { parseStrategySpec, StrategySpecOptions } from './strategy-loader';
 import {
   PassLineWithOdds1X,
   PassLineWithOdds2X,
@@ -91,9 +94,10 @@ export const BUILT_IN_STRATEGIES: Record<string, StrategyDefinition> = {
  * Factories for strategies that carry per-session runtime state (stage
  * machines). Multi-session runs MUST create a fresh instance per session —
  * the singletons in BUILT_IN_STRATEGIES carry stage, profit baseline, and
- * counters from one session into the next.
+ * counters from one session into the next. These factories accept the
+ * canonical spec options ({ entry?, tableMin? }).
  */
-const STRATEGY_FACTORIES: Record<string, () => StrategyDefinition> = {
+const STRATEGY_FACTORIES: Record<string, (options?: StrategySpecOptions) => StrategyDefinition> = {
   'BATS':                BATS,
   'BATSAccumulatorOnly': BATSAccumulatorOnly,
   'CATS':                CATS,
@@ -105,6 +109,12 @@ const STRATEGY_FACTORIES: Record<string, () => StrategyDefinition> = {
   'DoDontWithCome2X':    DoDontWithCome2X,
   'DoDontWithCome3X':    DoDontWithCome3X,
 };
+
+/**
+ * Strategies whose factories understand canonical spec options. Specs with
+ * options on any other name fail loudly rather than silently ignoring them.
+ */
+const PARAMETERIZED = new Set(['BATS', 'BATSAccumulatorOnly', 'CATS', 'CATSAccumulatorOnly']);
 
 /**
  * Look up a built-in strategy by name. Throws a descriptive error if the name
@@ -120,12 +130,55 @@ export function lookupStrategy(name: string): StrategyDefinition {
 }
 
 /**
- * Create a strategy instance for one session. Stage-machine strategies get a
- * fresh runtime; stateless strategies return the shared function (their only
- * state lives in the per-engine ReconcileEngine trackers).
+ * Create a strategy instance for one session from a canonical spec string
+ * (`NAME` or `NAME@key=value[,key=value]`, e.g. `CATS@entry=threePtMollyLoose`).
+ * Stage-machine strategies get a fresh runtime; stateless strategies return
+ * the shared function (their only state lives in the per-engine
+ * ReconcileEngine trackers). Unknown entry slugs fail loudly with the valid
+ * list (thrown by the stage machine, which owns the metadata).
  */
-export function createStrategy(name: string): StrategyDefinition {
+export function createStrategy(spec: string): StrategyDefinition {
+  const parsed = parseStrategySpec(spec);
+  const factory = STRATEGY_FACTORIES[parsed.name];
+
+  const hasOptions = Object.keys(parsed.options).length > 0;
+  if (hasOptions && !PARAMETERIZED.has(parsed.name)) {
+    throw new Error(
+      `Strategy "${parsed.name}" does not accept spec options. ` +
+      `Parameterizable strategies: ${[...PARAMETERIZED].sort().join(', ')}.`
+    );
+  }
+
+  if (factory) return factory(parsed.options);
+  return lookupStrategy(parsed.name);
+}
+
+/** Per-strategy stage metadata for UIs: ordered slugs, display names, gates. */
+export interface StrategyMetadata {
+  name: string;
+  /** Ordered funded-entry stages; empty for non-staged strategies. */
+  stages: StageMetadata[];
+  /** Whether the strategy accepts canonical spec options. */
+  parameterized: boolean;
+}
+
+/**
+ * Export a strategy's stage metadata so any UI can render an entry-stage
+ * dropdown generically. Instantiates the factory (cheap, no table context)
+ * and reads the stage machine's declared metadata.
+ */
+export function getStrategyMetadata(name: string): StrategyMetadata {
   const factory = STRATEGY_FACTORIES[name];
-  if (factory) return factory();
-  return lookupStrategy(name);
+  const instance = factory ? factory() : lookupStrategy(name);
+  const runtime = (instance as any)[STAGE_MACHINE_RUNTIME] as StageMachineRuntime | undefined;
+  return {
+    name,
+    stages: runtime ? runtime.getStageMetadata() : [],
+    parameterized: PARAMETERIZED.has(name),
+  };
+}
+
+/** All registry names, for UIs and error messages. */
+export function listStrategyNames(): string[] {
+  return Object.keys(BUILT_IN_STRATEGIES);
 }

--- a/src/dsl/stage-machine-state.ts
+++ b/src/dsl/stage-machine-state.ts
@@ -5,7 +5,7 @@
  * event dispatch, and transition evaluation.
  */
 
-import { StageConfig, StageContext, SessionState, TableReadView } from './stage-machine-types';
+import { StageConfig, StageContext, SessionState, TableReadView, StageMetadata } from './stage-machine-types';
 import { StrategyContext } from './strategy';
 import { CrapsTable } from '../craps-table';
 import { Outcome } from './outcome';
@@ -47,6 +47,25 @@ const NOOP_BET_RECONCILER: BetReconciler = {
   buy: () => {},
   remove: () => {},
 };
+
+/**
+ * Build the ordered slug → metadata table from a machine's stage configs.
+ * Rows appear in stage-declaration order; only stages with entry metadata
+ * are included (internal states like accumulatorRegressed are omitted).
+ */
+export function collectStageMetadata(stages: Map<string, StageConfig>): StageMetadata[] {
+  const rows: StageMetadata[] = [];
+  for (const [state, config] of stages) {
+    if (!config.entry) continue;
+    rows.push({
+      slug: config.entry.slug ?? state,
+      state,
+      displayName: config.entry.displayName,
+      gate: config.entry.gate,
+    });
+  }
+  return rows;
+}
 
 export class StageMachineRuntime {
   private currentStage: string;
@@ -116,6 +135,11 @@ export class StageMachineRuntime {
   /** Returns session state for external inspection (e.g., tests). */
   getSessionState(): SessionState {
     return this.sessionState;
+  }
+
+  /** Ordered funded-entry stage metadata (slugs, display names, gates). */
+  getStageMetadata(): StageMetadata[] {
+    return collectStageMetadata(this.stageConfigs);
   }
 
   /**

--- a/src/dsl/stage-machine-state.ts
+++ b/src/dsl/stage-machine-state.ts
@@ -143,6 +143,15 @@ export class StageMachineRuntime {
   }
 
   /**
+   * All machine states in declaration (ladder) order, including internal
+   * states without entry metadata. Index in this list is the state's ladder
+   * level — used by fall-below-stage stopping rules.
+   */
+  getStateOrder(): string[] {
+    return [...this.stageConfigs.keys()];
+  }
+
+  /**
    * Called by the StrategyDefinition wrapper on each reconcile pass.
    * Delegates to the current stage's board() function.
    */

--- a/src/dsl/stage-machine-state.ts
+++ b/src/dsl/stage-machine-state.ts
@@ -51,6 +51,8 @@ const NOOP_BET_RECONCILER: BetReconciler = {
 export class StageMachineRuntime {
   private currentStage: string;
   private lastBoardStage: string;
+  /** Funded-entry gate (v4 §2): origin = initialBankroll − entryGate. */
+  private entryGate: number;
   private stageTrackers = new Map<string, Map<string, any>>();
   private sessionState: MutableSessionState;
   private stageConfigs: Map<string, StageConfig>;
@@ -63,9 +65,11 @@ export class StageMachineRuntime {
     startingStage: string,
     configs: Map<string, StageConfig>,
     _machineName: string,
+    entryGate: number = 0,
   ) {
     this.currentStage = startingStage;
     this.lastBoardStage = startingStage;
+    this.entryGate = entryGate;
     this.stageConfigs = configs;
     this.sessionState = {
       profit: 0,
@@ -85,6 +89,12 @@ export class StageMachineRuntime {
     // Capture initial bankroll on first call (before any bets are placed)
     if (bankroll !== undefined && this.initialBankroll === null) {
       this.initialBankroll = bankroll;
+      // Session start: equity = bankroll, so profit = bankroll − origin =
+      // entryGate exactly. Without this, the first reconcile's retreat
+      // check would see the constructor's profit 0 and cascade a funded
+      // entry down the ladder before the first roll. Default entry has
+      // gate 0 — identical to the previous initialization.
+      this.sessionState.profit = this.entryGate;
     }
   }
 
@@ -144,8 +154,11 @@ export class StageMachineRuntime {
     rollValue: number,
   ): void {
     // Update profit per §3.7 accounting: (rack + working bets at face value)
-    // − buy-in, after payouts settle. Face value = flat + odds. Without table
-    // context (unit tests), felt load is 0 and profit is rack-only.
+    // − origin, after payouts settle. Face value = flat + odds. Origin is
+    // the funded-entry zero point (v4 §2): initialBankroll − entryGate, so
+    // a default entry (gate 0) reproduces the classic equity − buy-in and a
+    // funded entry starts with profit exactly at its stage's gate. Without
+    // table context (unit tests), felt load is 0 and profit is rack-only.
     // (initialBankroll is set in setTableContext on first reconcile call)
     if (this.initialBankroll !== null) {
       let feltLoad = 0;
@@ -154,7 +167,8 @@ export class StageMachineRuntime {
           feltLoad += bet.totalAmount;
         }
       }
-      this.sessionState.profit = bankroll + feltLoad - this.initialBankroll;
+      const origin = this.initialBankroll - this.entryGate;
+      this.sessionState.profit = bankroll + feltLoad - origin;
     }
 
     // Track seven-outs and hands played

--- a/src/dsl/stage-machine-types.ts
+++ b/src/dsl/stage-machine-types.ts
@@ -103,6 +103,35 @@ export interface StageContext {
 // Stage configuration
 // ---------------------------------------------------------------------------
 
+/**
+ * Entry metadata for a stage. Declaring it makes the stage a legal funded
+ * entry point (session-lifecycle.md v4 §2). Slugs are the stable keys used
+ * in canonical specs (`CATS@entry=threePtMollyLoose`), URLs, and manifests;
+ * display names are presentation metadata and may change.
+ */
+export interface StageEntryMeta {
+  /** Stable slug id. Defaults to the stage's machine-state name. */
+  slug?: string;
+  /** Human-facing display name, e.g. "3-Point Molly — Loose". */
+  displayName: string;
+  /**
+   * Profit gate above origin for entering this stage, in dollars.
+   * At session start, origin = bankroll − gate(entryStage), so a funded
+   * entry begins with profit exactly equal to this gate.
+   */
+  gate: number;
+}
+
+/** Machine-level options (second argument to stageMachine()). */
+export interface StageMachineOptions {
+  /**
+   * Funded entry: the slug of the stage to start in. Default = the
+   * startingAt() stage with gate 0 (classic behavior). Resolved against
+   * the declared StageEntryMeta slugs; unknown slugs fail loudly.
+   */
+  entryStage?: string;
+}
+
 /** Configuration for a single stage. */
 export interface StageConfig {
   /**
@@ -110,6 +139,13 @@ export interface StageConfig {
    * Same BetReconciler API as StrategyDefinition.
    */
   board: (ctx: StageContext) => void;
+
+  /**
+   * Entry metadata — presence makes this stage a funded-entry point and
+   * lists it in the exported stage metadata. Stages without it (e.g. the
+   * regressed Accumulator phase) are internal machine states.
+   */
+  entry?: StageEntryMeta;
 
   /**
    * Advance guard: returns true when stepping up to the named stage is
@@ -132,6 +168,18 @@ export interface StageConfig {
 // ---------------------------------------------------------------------------
 // Stage Machine builder
 // ---------------------------------------------------------------------------
+
+/** One row of a machine's exported stage metadata (for UIs and loaders). */
+export interface StageMetadata {
+  /** Stable slug id (canonical spec key). */
+  slug: string;
+  /** Machine-state name the slug enters at. */
+  state: string;
+  /** Human-facing display name. */
+  displayName: string;
+  /** Entry gate above origin, in dollars. */
+  gate: number;
+}
 
 /** Fluent builder for a Stage Machine. */
 export interface StageMachineBuilder {

--- a/src/dsl/stage-machine.ts
+++ b/src/dsl/stage-machine.ts
@@ -33,20 +33,8 @@ export function stageMachine(name: string, options: StageMachineOptions = {}): S
   return new StageMachineBuilderImpl(name, options);
 }
 
-/** Build the slug → metadata table from a machine's stage configs. */
-export function collectStageMetadata(stages: Map<string, StageConfig>): StageMetadata[] {
-  const rows: StageMetadata[] = [];
-  for (const [state, config] of stages) {
-    if (!config.entry) continue;
-    rows.push({
-      slug: config.entry.slug ?? state,
-      state,
-      displayName: config.entry.displayName,
-      gate: config.entry.gate,
-    });
-  }
-  return rows;
-}
+export { collectStageMetadata } from './stage-machine-state';
+import { collectStageMetadata } from './stage-machine-state';
 
 class StageMachineBuilderImpl implements StageMachineBuilder {
   private _name: string;

--- a/src/dsl/stage-machine.ts
+++ b/src/dsl/stage-machine.ts
@@ -14,6 +14,8 @@
 import {
   StageMachineBuilder,
   StageConfig,
+  StageMachineOptions,
+  StageMetadata,
 } from './stage-machine-types';
 import { StrategyDefinition, STAGE_MACHINE_RUNTIME } from './strategy';
 import { StageMachineRuntime } from './stage-machine-state';
@@ -21,18 +23,40 @@ import { StageMachineRuntime } from './stage-machine-state';
 /**
  * Entry point — creates a new Stage Machine builder.
  * The returned builder uses a fluent API: chain .startingAt(), .stage(), then .build().
+ *
+ * Funded entry (session-lifecycle.md v4 §2): pass { entryStage: <slug> }
+ * to start the session in that stage. The session origin becomes
+ * bankroll − gate(entryStage), so profit starts at exactly the stage's
+ * entry gate. Default entry = startingAt() with gate 0 (classic behavior).
  */
-export function stageMachine(name: string): StageMachineBuilder {
-  return new StageMachineBuilderImpl(name);
+export function stageMachine(name: string, options: StageMachineOptions = {}): StageMachineBuilder {
+  return new StageMachineBuilderImpl(name, options);
+}
+
+/** Build the slug → metadata table from a machine's stage configs. */
+export function collectStageMetadata(stages: Map<string, StageConfig>): StageMetadata[] {
+  const rows: StageMetadata[] = [];
+  for (const [state, config] of stages) {
+    if (!config.entry) continue;
+    rows.push({
+      slug: config.entry.slug ?? state,
+      state,
+      displayName: config.entry.displayName,
+      gate: config.entry.gate,
+    });
+  }
+  return rows;
 }
 
 class StageMachineBuilderImpl implements StageMachineBuilder {
   private _name: string;
+  private _options: StageMachineOptions;
   private _startingStage: string | undefined;
   private _stages = new Map<string, StageConfig>();
 
-  constructor(name: string) {
+  constructor(name: string, options: StageMachineOptions = {}) {
     this._name = name;
+    this._options = options;
   }
 
   startingAt(stageName: string): StageMachineBuilder {
@@ -72,15 +96,31 @@ class StageMachineBuilderImpl implements StageMachineBuilder {
       );
     }
 
+    // Resolve funded entry: entryStage is a slug matched against the
+    // declared entry metadata. Unknown slugs fail loudly with the valid
+    // list — slugs are the stable public keys.
+    const stages = new Map(this._stages);
+    const metadata = collectStageMetadata(stages);
+    let startingStage = this._startingStage;
+    let entryGate = 0;
+    if (this._options.entryStage !== undefined) {
+      const row = metadata.find(m => m.slug === this._options.entryStage);
+      if (!row) {
+        const valid = metadata.map(m => m.slug).join(', ');
+        throw new Error(
+          `Stage machine "${this._name}": unknown entry stage "${this._options.entryStage}". ` +
+          `Valid entry slugs: ${valid}`
+        );
+      }
+      startingStage = row.state;
+      entryGate = row.gate;
+    }
+
     // Build the runtime. Each call to the returned StrategyDefinition
     // delegates to the runtime, which tracks stage state across rolls.
-    // The runtime is created lazily on first call so that the bankroll
-    // can be derived from the engine context.
-    const stages = new Map(this._stages);
-    const startingStage = this._startingStage;
     const machineName = this._name;
 
-    const runtime = new StageMachineRuntime(startingStage, stages, machineName);
+    const runtime = new StageMachineRuntime(startingStage, stages, machineName, entryGate);
 
     const strategyFn: StrategyDefinition = (ctx) => {
       runtime.onStrategyCall(ctx);

--- a/src/dsl/strategies-staged.ts
+++ b/src/dsl/strategies-staged.ts
@@ -16,9 +16,11 @@
  *
  * Tight and Loose are MODES of one stage (stage 3): the §3.4 seven-out
  * step-down from either mode lands in littleMolly; Loose ⇄ Tight shifts on
- * the ±$200 cushion are mode changes, not step-downs. §3.4's hard reset
- * (profit < +$20) returns any stage to accumulatorRegressed. Profit follows
- * §3.7: (rack + working bets at face) − buy-in, settled per roll.
+ * the ±$200 cushion are mode changes, not step-downs. The former §3.4 hard
+ * reset (profit < +$20 → jump to Accumulator) is RETIRED (v4 decision #3):
+ * descent is handled entirely by the chained retreat floors, which reach
+ * the Accumulator from any stage with no dead zone. Profit follows §3.7:
+ * (rack + working bets at face) − origin, settled per roll.
  *
  * CATSAccumulatorOnly stages:
  *   accumulatorFull    → Place 6/8 at $18 each. Transitions on first 6/8 hit.
@@ -46,10 +48,8 @@ export interface CATSOptions {
   /**
    * Stage 1 → 2 (Little Molly) profit gate in dollars (default 7u = $70 at
    * a $10 table). All higher ladder gates scale proportionally (rounded to
-   * the dollar). The §3.4 hard-reset floor does not scale with the gate —
-   * it is a capital-preservation floor, not a rung of the gate ladder.
-   * Used for threshold-sensitivity analysis; the strategy's official
-   * thresholds are unchanged.
+   * the dollar). Used for threshold-sensitivity analysis; the strategy's
+   * official thresholds are unchanged.
    */
   stage2Gate?: number;
   /**
@@ -79,7 +79,6 @@ export function CATS(options: CATSOptions = {}) {
   const G_LOOSE    = Math.round(U.modeShiftCushion * f);       // Tight ⇄ Loose mode-shift cushion
   const G_EXPANDED = Math.round(U.gates.expandedAlpha * f);    // Stage 3 → 4 gate; Expanded Alpha retreat floor
   const G_MAX      = Math.round(U.gates.maxAlpha * f);         // Stage 4 → 5 gate; Max Alpha retreat floor
-  const HARD_RESET = U.hardReset;                              // §3.4 hard reset — not gate-scaled
 
   return stageMachine('CATS', { entryStage: options.entry })
     .startingAt('accumulatorFull')
@@ -152,7 +151,6 @@ export function CATS(options: CATSOptions = {}) {
       },
       canAdvanceTo: (_target, session) => session.profit >= G_LOOSE,
       mustRetreatTo: (session) => {
-        if (session.profit < HARD_RESET) return 'accumulatorRegressed'; // §3.4 hard reset
         if (session.profit < G_MOLLY || session.sevenOutStepDownTriggered) return 'littleMolly';
         return undefined;
       },
@@ -181,7 +179,6 @@ export function CATS(options: CATSOptions = {}) {
       },
       canAdvanceTo: (_target, session) => session.profit >= G_EXPANDED,
       mustRetreatTo: (session) => {
-        if (session.profit < HARD_RESET) return 'accumulatorRegressed'; // §3.4 hard reset
         if (session.profit < G_MOLLY || session.sevenOutStepDownTriggered) return 'littleMolly';
         if (session.profit < G_LOOSE) return 'threePtMollyTight';
         return undefined;
@@ -210,7 +207,6 @@ export function CATS(options: CATSOptions = {}) {
       },
       canAdvanceTo: (_target, session) => session.profit >= G_MAX,
       mustRetreatTo: (session) => {
-        if (session.profit < HARD_RESET) return 'accumulatorRegressed'; // §3.4 hard reset
         if (session.profit < G_EXPANDED || session.sevenOutStepDownTriggered) return 'threePtMollyLoose';
         return undefined;
       },
@@ -232,7 +228,6 @@ export function CATS(options: CATSOptions = {}) {
         if (!table.coverage.has(9)) bets.buy(9, U.buyAmount);
       },
       mustRetreatTo: (session) => {
-        if (session.profit < HARD_RESET) return 'accumulatorRegressed'; // §3.4 hard reset
         if (session.profit < G_MAX || session.sevenOutStepDownTriggered) return 'expandedAlpha';
         return undefined;
       },

--- a/src/dsl/strategies-staged.ts
+++ b/src/dsl/strategies-staged.ts
@@ -57,6 +57,13 @@ export interface CATSOptions {
    * buys, accumulator amounts, gates — derives from it via catsUnits().
    */
   tableMin?: number;
+  /**
+   * Funded entry (v4 §2): stable stage slug to start the session in
+   * ('accumulator', 'littleMolly', 'threePtMollyTight',
+   * 'threePtMollyLoose', 'expandedAlpha', 'maxAlpha'). Origin becomes
+   * bankroll − gate(entry); default = 'accumulator' (classic behavior).
+   */
+  entry?: string;
 }
 
 /**
@@ -74,12 +81,13 @@ export function CATS(options: CATSOptions = {}) {
   const G_MAX      = Math.round(U.gates.maxAlpha * f);         // Stage 4 → 5 gate; Max Alpha retreat floor
   const HARD_RESET = U.hardReset;                              // §3.4 hard reset — not gate-scaled
 
-  return stageMachine('CATS')
+  return stageMachine('CATS', { entryStage: options.entry })
     .startingAt('accumulatorFull')
 
     // --- Stage 1: Accumulator Full ---
     // Place 6/8 at $18 each. On first hit of 6 or 8, transition to regressed.
     .stage('accumulatorFull', {
+      entry: { slug: 'accumulator', displayName: 'Accumulator', gate: 0 },
       board: ({ bets }: StageContext) => {
         bets.place(6, U.accumulatorStart);
         bets.place(8, U.accumulatorStart);
@@ -112,6 +120,7 @@ export function CATS(options: CATSOptions = {}) {
     // Advances to ThreePtMollyTight at +$150.
     // Retreats to AccumulatorRegressed on profit < +$70 or a 7-out trigger.
     .stage('littleMolly', {
+      entry: { displayName: 'Little Molly', gate: G_LITTLE },
       board: ({ bets, session, advanceTo }: StageContext) => {
         bets.passLine(U.flat).withOdds(U.oddsLittle);
         bets.come(U.flat).withOdds(U.oddsLittle);
@@ -131,6 +140,7 @@ export function CATS(options: CATSOptions = {}) {
     // Shifts to Loose (mode change) at +$200 when 6 or 8 is covered.
     // Steps down to LittleMolly on profit < +$150 or a 7-out trigger.
     .stage('threePtMollyTight', {
+      entry: { displayName: '3-Point Molly — Tight', gate: G_MOLLY },
       board: ({ bets, table, session, advanceTo }: StageContext) => {
         const odds = tieredOdds(table, U);
         bets.passLine(U.flat).withOdds(odds.passLine);
@@ -155,6 +165,12 @@ export function CATS(options: CATSOptions = {}) {
     // < +$150 steps down a full stage to LittleMolly; dropping below the
     // +$200 cushion shifts back to Tight (mode change, not a step-down).
     .stage('threePtMollyLoose', {
+      // Funded Loose entry is gated at 25u — the top of stage 3's band
+      // (v4 §4 ladder / work order: $300 entry → origin $50, profit $250).
+      // It shares the 25u value with expandedAlpha's entry gate, so a
+      // Loose entry at exactly its gate immediately qualifies to advance:
+      // v4 decision #1, the physics handles the rest.
+      entry: { displayName: '3-Point Molly — Loose', gate: G_EXPANDED },
       board: ({ bets, session, advanceTo }: StageContext) => {
         bets.passLine(U.flat).withOdds(U.oddsLoose);
         bets.come(U.flat).withOdds(U.oddsLoose);
@@ -181,6 +197,7 @@ export function CATS(options: CATSOptions = {}) {
     // Advances to MaxAlpha at +$400. Steps down to Loose Molly on profit
     // < +$250 or a 7-out trigger.
     .stage('expandedAlpha', {
+      entry: { displayName: 'Expanded Alpha', gate: G_EXPANDED },
       board: ({ bets, table, session, advanceTo }: StageContext) => {
         bets.passLine(U.flat).withOdds(U.oddsLoose);
         bets.come(U.flat).withOdds(U.oddsLoose);
@@ -204,6 +221,7 @@ export function CATS(options: CATSOptions = {}) {
     // Swap Rule applies to all four buy numbers.
     // Steps down to ExpandedAlpha on profit < +$400 or a 7-out trigger.
     .stage('maxAlpha', {
+      entry: { displayName: 'Max Alpha', gate: G_MAX },
       board: ({ bets, table }: StageContext) => {
         bets.passLine(U.flat).withOdds(U.oddsLoose);
         bets.come(U.flat).withOdds(U.oddsLoose);
@@ -305,15 +323,16 @@ function layAmountToWin(point: number, targetWin: number): number {
  * Creates a fresh BATS strategy. Each call produces an independent runtime.
  * Register in StrategyRegistry as: `'BATS': BATS()`
  */
-export function BATS(options: { tableMin?: number } = {}) {
+export function BATS(options: { tableMin?: number; entry?: string } = {}) {
   const B = batsUnits(options.tableMin ?? 10);
-  return stageMachine('BATS')
+  return stageMachine('BATS', { entryStage: options.entry })
     .startingAt('bearishAccumulator')
 
     // --- Stage 1: Bearish Accumulator ---
     // Don't Pass only. Lay odds sized to win 1 unit ($10).
     // Advance at profit ≥ +$120.
     .stage('bearishAccumulator', {
+      entry: { displayName: 'Bearish Accumulator', gate: 0 },
       board: ({ bets, table, session, advanceTo }: StageContext) => {
         if (!table.point) {
           bets.dontPass(B.flat);
@@ -330,6 +349,7 @@ export function BATS(options: { tableMin?: number } = {}) {
     // Retreat: 2 consecutive come-out losses OR profit drops below +$120.
     // Advance at profit ≥ +$225.
     .stage('littleDolly', {
+      entry: { displayName: 'Little Dolly', gate: B.gates.littleDolly },
       board: ({ bets, table, session, advanceTo }: StageContext) => {
         if (!table.point) {
           bets.dontPass(10);
@@ -353,6 +373,7 @@ export function BATS(options: { tableMin?: number } = {}) {
     // Retreat: point repeater streak ≥ 2 OR profit drops below +$225.
     // Advance at profit ≥ +$350.
     .stage('threePtDolly', {
+      entry: { displayName: '3-Point Dolly', gate: B.gates.threePtDolly },
       board: ({ bets, table, session, advanceTo }: StageContext) => {
         if (!table.point) {
           bets.dontPass(10);
@@ -378,6 +399,7 @@ export function BATS(options: { tableMin?: number } = {}) {
     // Retreat: profit drops below +$350.
     // Advance at profit ≥ +$500.
     .stage('expandedDarkAlpha', {
+      entry: { displayName: 'Expanded Dark Alpha', gate: B.gates.expandedDarkAlpha },
       board: ({ bets, table, session, advanceTo }: StageContext) => {
         if (!table.point) {
           bets.dontPass(10);
@@ -404,6 +426,7 @@ export function BATS(options: { tableMin?: number } = {}) {
     // Swap Rule applies to all four lay numbers.
     // Retreat: profit drops below +$500.
     .stage('maxDarkAlpha', {
+      entry: { displayName: 'Max Dark Alpha', gate: B.gates.maxDarkAlpha },
       board: ({ bets, table }: StageContext) => {
         if (!table.point) {
           bets.dontPass(10);

--- a/src/dsl/strategies-staged.ts
+++ b/src/dsl/strategies-staged.ts
@@ -39,18 +39,24 @@
 import { stageMachine } from './stage-machine';
 import { StageContext, TableReadView } from './stage-machine-types';
 import { StrategyDefinition } from './strategy';
+import { catsUnits, batsUnits, CatsUnits } from './units';
 
 /** Options for CATS(). Defaults reproduce the strategy doc exactly. */
 export interface CATSOptions {
   /**
-   * Stage 1 → 2 (Little Molly) profit gate in dollars (default $70).
-   * All higher ladder gates scale proportionally (rounded to the dollar):
-   * $150/$200/$250/$400 × (stage2Gate / 70). The §3.4 hard-reset floor
-   * stays at $20 — it is a capital-preservation floor tied to the buy-in,
-   * not a rung of the gate ladder. Used for threshold-sensitivity analysis;
-   * the strategy's official thresholds are unchanged.
+   * Stage 1 → 2 (Little Molly) profit gate in dollars (default 7u = $70 at
+   * a $10 table). All higher ladder gates scale proportionally (rounded to
+   * the dollar). The §3.4 hard-reset floor does not scale with the gate —
+   * it is a capital-preservation floor, not a rung of the gate ladder.
+   * Used for threshold-sensitivity analysis; the strategy's official
+   * thresholds are unchanged.
    */
   stage2Gate?: number;
+  /**
+   * Table minimum (default $10). Every sizing quantity — flats, odds,
+   * buys, accumulator amounts, gates — derives from it via catsUnits().
+   */
+  tableMin?: number;
 }
 
 /**
@@ -58,14 +64,15 @@ export interface CATSOptions {
  * Register in StrategyRegistry as: `'CATS': CATS()`
  */
 export function CATS(options: CATSOptions = {}) {
-  const g2 = options.stage2Gate ?? 70;
-  const f = g2 / 70;
-  const G_LITTLE   = g2;                    // Stage 1 → 2 gate; Little Molly retreat floor
-  const G_MOLLY    = Math.round(150 * f);   // Stage 2 → 3 gate; stage-3 retreat floor
-  const G_LOOSE    = Math.round(200 * f);   // Tight ⇄ Loose mode-shift cushion
-  const G_EXPANDED = Math.round(250 * f);   // Stage 3 → 4 gate; Expanded Alpha retreat floor
-  const G_MAX      = Math.round(400 * f);   // Stage 4 → 5 gate; Max Alpha retreat floor
-  const HARD_RESET = 20;                    // §3.4 hard reset — not scaled
+  const U = catsUnits(options.tableMin ?? 10);
+  const g2 = options.stage2Gate ?? U.gates.littleMolly;
+  const f = g2 / U.gates.littleMolly;
+  const G_LITTLE   = g2;                                       // Stage 1 → 2 gate; Little Molly retreat floor
+  const G_MOLLY    = Math.round(U.gates.threePtMolly * f);     // Stage 2 → 3 gate; stage-3 retreat floor
+  const G_LOOSE    = Math.round(U.modeShiftCushion * f);       // Tight ⇄ Loose mode-shift cushion
+  const G_EXPANDED = Math.round(U.gates.expandedAlpha * f);    // Stage 3 → 4 gate; Expanded Alpha retreat floor
+  const G_MAX      = Math.round(U.gates.maxAlpha * f);         // Stage 4 → 5 gate; Max Alpha retreat floor
+  const HARD_RESET = U.hardReset;                              // §3.4 hard reset — not gate-scaled
 
   return stageMachine('CATS')
     .startingAt('accumulatorFull')
@@ -74,8 +81,8 @@ export function CATS(options: CATSOptions = {}) {
     // Place 6/8 at $18 each. On first hit of 6 or 8, transition to regressed.
     .stage('accumulatorFull', {
       board: ({ bets }: StageContext) => {
-        bets.place(6, 18);
-        bets.place(8, 18);
+        bets.place(6, U.accumulatorStart);
+        bets.place(8, U.accumulatorStart);
       },
       canAdvanceTo: () => true,
       on: {
@@ -91,8 +98,8 @@ export function CATS(options: CATSOptions = {}) {
     // Place 6/8 at $12 each. Advance to LittleMolly when profit >= +$70.
     .stage('accumulatorRegressed', {
       board: ({ bets, session, advanceTo }: StageContext) => {
-        bets.place(6, 12);
-        bets.place(8, 12);
+        bets.place(6, U.accumulatorRegressed);
+        bets.place(8, U.accumulatorRegressed);
         if (session.profit >= G_LITTLE) {
           advanceTo('littleMolly');
         }
@@ -106,8 +113,8 @@ export function CATS(options: CATSOptions = {}) {
     // Retreats to AccumulatorRegressed on profit < +$70 or a 7-out trigger.
     .stage('littleMolly', {
       board: ({ bets, session, advanceTo }: StageContext) => {
-        bets.passLine(10).withOdds(20);
-        bets.come(10).withOdds(20);
+        bets.passLine(U.flat).withOdds(U.oddsLittle);
+        bets.come(U.flat).withOdds(U.oddsLittle);
         if (session.profit >= G_MOLLY) {
           advanceTo('threePtMollyTight');
         }
@@ -125,10 +132,10 @@ export function CATS(options: CATSOptions = {}) {
     // Steps down to LittleMolly on profit < +$150 or a 7-out trigger.
     .stage('threePtMollyTight', {
       board: ({ bets, table, session, advanceTo }: StageContext) => {
-        const odds = tieredOdds(table);
-        bets.passLine(10).withOdds(odds.passLine);
-        bets.come(10).withOdds(odds.come1);
-        bets.come(10).withOdds(odds.come2);
+        const odds = tieredOdds(table, U);
+        bets.passLine(U.flat).withOdds(odds.passLine);
+        bets.come(U.flat).withOdds(odds.come1);
+        bets.come(U.flat).withOdds(odds.come2);
         if (session.profit >= G_LOOSE && table.hasSixOrEight) {
           advanceTo('threePtMollyLoose');
         }
@@ -149,9 +156,9 @@ export function CATS(options: CATSOptions = {}) {
     // +$200 cushion shifts back to Tight (mode change, not a step-down).
     .stage('threePtMollyLoose', {
       board: ({ bets, session, advanceTo }: StageContext) => {
-        bets.passLine(10).withOdds(50);
-        bets.come(10).withOdds(50);
-        bets.come(10).withOdds(50);
+        bets.passLine(U.flat).withOdds(U.oddsLoose);
+        bets.come(U.flat).withOdds(U.oddsLoose);
+        bets.come(U.flat).withOdds(U.oddsLoose);
         if (session.profit >= G_EXPANDED) {
           advanceTo('expandedAlpha');
         }
@@ -175,11 +182,11 @@ export function CATS(options: CATSOptions = {}) {
     // < +$250 or a 7-out trigger.
     .stage('expandedAlpha', {
       board: ({ bets, table, session, advanceTo }: StageContext) => {
-        bets.passLine(10).withOdds(50);
-        bets.come(10).withOdds(50);
-        bets.come(10).withOdds(50);
-        if (!table.coverage.has(4)) bets.buy(4, 20);
-        if (!table.coverage.has(10)) bets.buy(10, 20);
+        bets.passLine(U.flat).withOdds(U.oddsLoose);
+        bets.come(U.flat).withOdds(U.oddsLoose);
+        bets.come(U.flat).withOdds(U.oddsLoose);
+        if (!table.coverage.has(4)) bets.buy(4, U.buyAmount);
+        if (!table.coverage.has(10)) bets.buy(10, U.buyAmount);
         if (session.profit >= G_MAX) {
           advanceTo('maxAlpha');
         }
@@ -198,13 +205,13 @@ export function CATS(options: CATSOptions = {}) {
     // Steps down to ExpandedAlpha on profit < +$400 or a 7-out trigger.
     .stage('maxAlpha', {
       board: ({ bets, table }: StageContext) => {
-        bets.passLine(10).withOdds(50);
-        bets.come(10).withOdds(50);
-        bets.come(10).withOdds(50);
-        if (!table.coverage.has(4)) bets.buy(4, 20);
-        if (!table.coverage.has(10)) bets.buy(10, 20);
-        if (!table.coverage.has(5)) bets.buy(5, 20);
-        if (!table.coverage.has(9)) bets.buy(9, 20);
+        bets.passLine(U.flat).withOdds(U.oddsLoose);
+        bets.come(U.flat).withOdds(U.oddsLoose);
+        bets.come(U.flat).withOdds(U.oddsLoose);
+        if (!table.coverage.has(4)) bets.buy(4, U.buyAmount);
+        if (!table.coverage.has(10)) bets.buy(10, U.buyAmount);
+        if (!table.coverage.has(5)) bets.buy(5, U.buyAmount);
+        if (!table.coverage.has(9)) bets.buy(9, U.buyAmount);
       },
       mustRetreatTo: (session) => {
         if (session.profit < HARD_RESET) return 'accumulatorRegressed'; // §3.4 hard reset
@@ -224,7 +231,8 @@ export function CATS(options: CATSOptions = {}) {
  *
  * Register in StrategyRegistry as: `'CATSAccumulatorOnly': CATSAccumulatorOnly()`
  */
-export function CATSAccumulatorOnly() {
+export function CATSAccumulatorOnly(options: { tableMin?: number } = {}) {
+  const U = catsUnits(options.tableMin ?? 10);
   return stageMachine('CATSAccumulatorOnly')
     .startingAt('accumulatorFull')
 
@@ -232,8 +240,8 @@ export function CATSAccumulatorOnly() {
     // Place 6/8 at $18 each. On first hit of 6 or 8, de-leverage to regressed.
     .stage('accumulatorFull', {
       board: ({ bets }: StageContext) => {
-        bets.place(6, 18);
-        bets.place(8, 18);
+        bets.place(6, U.accumulatorStart);
+        bets.place(8, U.accumulatorStart);
       },
       canAdvanceTo: () => true,
       on: {
@@ -249,8 +257,8 @@ export function CATSAccumulatorOnly() {
     // Place 6/8 at $12 each. No further advancement — grind indefinitely.
     .stage('accumulatorRegressed', {
       board: ({ bets }: StageContext) => {
-        bets.place(6, 12);
-        bets.place(8, 12);
+        bets.place(6, U.accumulatorRegressed);
+        bets.place(8, U.accumulatorRegressed);
       },
     })
 
@@ -264,13 +272,13 @@ export function CATSAccumulatorOnly() {
  * Middle (6/8 covered, no 5/9): 2×/1×/1× = $20/$10/$10
  * Rough (no 6/8): 1×/1×/1× = $10/$10/$10
  */
-function tieredOdds(table: TableReadView) {
+function tieredOdds(table: TableReadView, units: CatsUnits) {
   if (table.hasSixOrEight && hasPointInSet(table.coverage, [5, 9])) {
-    return { passLine: 30, come1: 20, come2: 10 };
+    return units.tier.sweet;
   } else if (table.hasSixOrEight) {
-    return { passLine: 20, come1: 10, come2: 10 };
+    return units.tier.middle;
   }
-  return { passLine: 10, come1: 10, come2: 10 };
+  return units.tier.rough;
 }
 
 // ---------------------------------------------------------------------------
@@ -297,7 +305,8 @@ function layAmountToWin(point: number, targetWin: number): number {
  * Creates a fresh BATS strategy. Each call produces an independent runtime.
  * Register in StrategyRegistry as: `'BATS': BATS()`
  */
-export function BATS() {
+export function BATS(options: { tableMin?: number } = {}) {
+  const B = batsUnits(options.tableMin ?? 10);
   return stageMachine('BATS')
     .startingAt('bearishAccumulator')
 
@@ -307,13 +316,13 @@ export function BATS() {
     .stage('bearishAccumulator', {
       board: ({ bets, table, session, advanceTo }: StageContext) => {
         if (!table.point) {
-          bets.dontPass(10);
+          bets.dontPass(B.flat);
         } else {
-          bets.dontPass(10).withOdds(layAmountToWin(table.point, 10));
+          bets.dontPass(B.flat).withOdds(layAmountToWin(table.point, B.layWinAccumulator));
         }
-        if (session.profit >= 120) advanceTo('littleDolly');
+        if (session.profit >= B.gates.littleDolly) advanceTo('littleDolly');
       },
-      canAdvanceTo: (_target, session) => session.profit >= 120,
+      canAdvanceTo: (_target, session) => session.profit >= B.gates.littleDolly,
     })
 
     // --- Stage 2: Little Dolly ---
@@ -325,16 +334,16 @@ export function BATS() {
         if (!table.point) {
           bets.dontPass(10);
         } else {
-          const layAmt = layAmountToWin(table.point, 20); // 2× odds: win $20
-          bets.dontPass(10).withOdds(layAmt);
-          bets.dontCome(10).withOdds(layAmt);
+          const layAmt = layAmountToWin(table.point, B.layWinDolly); // 2× odds
+          bets.dontPass(B.flat).withOdds(layAmt);
+          bets.dontCome(B.flat).withOdds(layAmt);
         }
-        if (session.profit >= 225) advanceTo('threePtDolly');
+        if (session.profit >= B.gates.threePtDolly) advanceTo('threePtDolly');
       },
-      canAdvanceTo: (_target, session) => session.profit >= 225,
+      canAdvanceTo: (_target, session) => session.profit >= B.gates.threePtDolly,
       mustRetreatTo: (session) => {
         if (session.consecutiveComeOutLosses >= 2) return 'bearishAccumulator';
-        if (session.profit < 120) return 'bearishAccumulator';
+        if (session.profit < B.gates.littleDolly) return 'bearishAccumulator';
         return undefined;
       },
     })
@@ -348,17 +357,17 @@ export function BATS() {
         if (!table.point) {
           bets.dontPass(10);
         } else {
-          const layAmt = layAmountToWin(table.point, 50); // 5× odds: win $50
-          bets.dontPass(10).withOdds(layAmt);
-          bets.dontCome(10).withOdds(layAmt);
-          bets.dontCome(10).withOdds(layAmt);
+          const layAmt = layAmountToWin(table.point, B.layWinThreePt); // 5× odds
+          bets.dontPass(B.flat).withOdds(layAmt);
+          bets.dontCome(B.flat).withOdds(layAmt);
+          bets.dontCome(B.flat).withOdds(layAmt);
         }
-        if (session.profit >= 350) advanceTo('expandedDarkAlpha');
+        if (session.profit >= B.gates.expandedDarkAlpha) advanceTo('expandedDarkAlpha');
       },
-      canAdvanceTo: (_target, session) => session.profit >= 350,
+      canAdvanceTo: (_target, session) => session.profit >= B.gates.expandedDarkAlpha,
       mustRetreatTo: (session) => {
         if (session.pointRepeaterStreak >= 2) return 'littleDolly';
-        if (session.profit < 225) return 'littleDolly';
+        if (session.profit < B.gates.threePtDolly) return 'littleDolly';
         return undefined;
       },
     })
@@ -373,19 +382,19 @@ export function BATS() {
         if (!table.point) {
           bets.dontPass(10);
         } else {
-          const layAmt = layAmountToWin(table.point, 50);
-          bets.dontPass(10).withOdds(layAmt);
-          bets.dontCome(10).withOdds(layAmt);
-          bets.dontCome(10).withOdds(layAmt);
+          const layAmt = layAmountToWin(table.point, B.layWinThreePt);
+          bets.dontPass(B.flat).withOdds(layAmt);
+          bets.dontCome(B.flat).withOdds(layAmt);
+          bets.dontCome(B.flat).withOdds(layAmt);
         }
         // Swap Rule: skip Lay if a DC bet has already traveled to that number.
-        if (!table.dontCoverage.has(4))  bets.lay(4, 40);  // Lay $40 → win $20 on 4
-        if (!table.dontCoverage.has(10)) bets.lay(10, 40); // Lay $40 → win $20 on 10
-        if (session.profit >= 500) advanceTo('maxDarkAlpha');
+        if (!table.dontCoverage.has(4))  bets.lay(4, layAmountToWin(4, B.layWinStandalone));
+        if (!table.dontCoverage.has(10)) bets.lay(10, layAmountToWin(10, B.layWinStandalone));
+        if (session.profit >= B.gates.maxDarkAlpha) advanceTo('maxDarkAlpha');
       },
-      canAdvanceTo: (_target, session) => session.profit >= 500,
+      canAdvanceTo: (_target, session) => session.profit >= B.gates.maxDarkAlpha,
       mustRetreatTo: (session) => {
-        if (session.profit < 350) return 'threePtDolly';
+        if (session.profit < B.gates.expandedDarkAlpha) return 'threePtDolly';
         return undefined;
       },
     })
@@ -399,18 +408,18 @@ export function BATS() {
         if (!table.point) {
           bets.dontPass(10);
         } else {
-          const layAmt = layAmountToWin(table.point, 50);
-          bets.dontPass(10).withOdds(layAmt);
-          bets.dontCome(10).withOdds(layAmt);
-          bets.dontCome(10).withOdds(layAmt);
+          const layAmt = layAmountToWin(table.point, B.layWinThreePt);
+          bets.dontPass(B.flat).withOdds(layAmt);
+          bets.dontCome(B.flat).withOdds(layAmt);
+          bets.dontCome(B.flat).withOdds(layAmt);
         }
-        if (!table.dontCoverage.has(4))  bets.lay(4,  40); // win $20
-        if (!table.dontCoverage.has(5))  bets.lay(5,  30); // lay $30 → win $20
-        if (!table.dontCoverage.has(9))  bets.lay(9,  30); // lay $30 → win $20
-        if (!table.dontCoverage.has(10)) bets.lay(10, 40); // win $20
+        if (!table.dontCoverage.has(4))  bets.lay(4,  layAmountToWin(4, B.layWinStandalone));
+        if (!table.dontCoverage.has(5))  bets.lay(5,  layAmountToWin(5, B.layWinStandalone));
+        if (!table.dontCoverage.has(9))  bets.lay(9,  layAmountToWin(9, B.layWinStandalone));
+        if (!table.dontCoverage.has(10)) bets.lay(10, layAmountToWin(10, B.layWinStandalone));
       },
       mustRetreatTo: (session) => {
-        if (session.profit < 500) return 'expandedDarkAlpha';
+        if (session.profit < B.gates.maxDarkAlpha) return 'expandedDarkAlpha';
         return undefined;
       },
     })
@@ -427,7 +436,8 @@ export function BATS() {
  *
  * Register in StrategyRegistry as: `'BATSAccumulatorOnly': BATSAccumulatorOnly()`
  */
-export function BATSAccumulatorOnly() {
+export function BATSAccumulatorOnly(options: { tableMin?: number } = {}) {
+  const B = batsUnits(options.tableMin ?? 10);
   return stageMachine('BATSAccumulatorOnly')
     .startingAt('bearishAccumulatorFull')
 
@@ -436,9 +446,9 @@ export function BATSAccumulatorOnly() {
     .stage('bearishAccumulatorFull', {
       board: ({ bets, table }: StageContext) => {
         if (!table.point) {
-          bets.dontPass(10);
+          bets.dontPass(B.flat);
         } else {
-          bets.dontPass(10).withOdds(layAmountToWin(table.point, 20));
+          bets.dontPass(B.flat).withOdds(layAmountToWin(table.point, B.layWinDolly));
         }
       },
       canAdvanceTo: () => true,
@@ -454,9 +464,9 @@ export function BATSAccumulatorOnly() {
     .stage('bearishAccumulatorRegressed', {
       board: ({ bets, table }: StageContext) => {
         if (!table.point) {
-          bets.dontPass(10);
+          bets.dontPass(B.flat);
         } else {
-          bets.dontPass(10).withOdds(layAmountToWin(table.point, 10));
+          bets.dontPass(B.flat).withOdds(layAmountToWin(table.point, B.layWinAccumulator));
         }
       },
     })

--- a/src/dsl/units.ts
+++ b/src/dsl/units.ts
@@ -58,8 +58,6 @@ export interface CatsUnits {
   };
   /** Tight ⇄ Loose mode-shift cushion: 20u. */
   modeShiftCushion: number;
-  /** §3.4 hard-reset floor: 2u. */
-  hardReset: number;
   /** Classic declared session risk B: 30u. */
   classicRisk: number;
   /** Reference funded configs (v4 §4): declared risk for funded entries. */
@@ -94,7 +92,6 @@ export function catsUnits(tableMin: number = 10): CatsUnits {
       maxAlpha: 40 * u,
     },
     modeShiftCushion: 20 * u,
-    hardReset: 2 * u,
     classicRisk: 30 * u,
     referenceFunded: {
       tight: 20 * u,

--- a/src/dsl/units.ts
+++ b/src/dsl/units.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit system — every CATS/BATS sizing quantity derived from the table
+ * minimum. One "unit" (u) is the table minimum. The v1.2 strategy doc's
+ * dollar figures are the $10-table instantiation of these rules:
+ *
+ *   Gates above origin:      7u / 15u / 25u / 40u  → $70/150/250/400 @ $10
+ *   Pass/Come flat:          1u; odds 2× (Little), 5× (Loose), 3-2-1× (Tight)
+ *   Buy 4/10 and 5/9:        2u each ($20 @ $10; $30 @ $15)
+ *   Accumulator start:       min proper place bet + $6 (the 6/8 place step)
+ *   Accumulator regressed:   min proper place bet ($12 @ $10; $18 @ $15)
+ *   Classic declared risk B: 30u
+ */
+
+/**
+ * Minimum proper place bet on a number at a given table minimum.
+ * 6/8 pay 7:6 — proper bets are multiples of $6; 4/5/9/10 pay x:5 —
+ * multiples of $5. The minimum proper bet is the smallest such multiple
+ * at or above the table minimum.
+ */
+export function minPlaceBet(num: number, tableMin: number): number {
+  const step = (num === 6 || num === 8) ? 6 : 5;
+  return Math.ceil(tableMin / step) * step;
+}
+
+/** The place-bet increment for a number ($6 on 6/8, $5 elsewhere). */
+export function placeStep(num: number): number {
+  return (num === 6 || num === 8) ? 6 : 5;
+}
+
+export interface CatsUnits {
+  tableMin: number;
+  /** One unit = the table minimum. */
+  unit: number;
+  /** Pass/Come flat bet: 1u. */
+  flat: number;
+  /** Little Molly odds: 2× flat. */
+  oddsLittle: number;
+  /** Loose Molly odds: 5× flat. */
+  oddsLoose: number;
+  /** Tight Molly tiered odds (3-2-1× flat by coverage state). */
+  tier: {
+    sweet: { passLine: number; come1: number; come2: number };
+    middle: { passLine: number; come1: number; come2: number };
+    rough: { passLine: number; come1: number; come2: number };
+  };
+  /** Buy 4/10/5/9 amount: 2u. */
+  buyAmount: number;
+  /** Accumulator opening place bet on each of 6/8: min proper bet + $6. */
+  accumulatorStart: number;
+  /** Regressed place bet on each of 6/8: min proper bet. */
+  accumulatorRegressed: number;
+  /** Profit gates above origin (7u / 15u / 25u / 40u). */
+  gates: {
+    littleMolly: number;
+    threePtMolly: number;
+    expandedAlpha: number;
+    maxAlpha: number;
+  };
+  /** Tight ⇄ Loose mode-shift cushion: 20u. */
+  modeShiftCushion: number;
+  /** §3.4 hard-reset floor: 2u. */
+  hardReset: number;
+  /** Classic declared session risk B: 30u. */
+  classicRisk: number;
+  /** Reference funded configs (v4 §4): declared risk for funded entries. */
+  referenceFunded: {
+    /** B for a Tight-Molly funded entry: 20u. */
+    tight: number;
+    /** B for a Little-Molly funded entry: 15u. */
+    littleMolly: number;
+  };
+}
+
+export function catsUnits(tableMin: number = 10): CatsUnits {
+  const u = tableMin;
+  return {
+    tableMin,
+    unit: u,
+    flat: u,
+    oddsLittle: 2 * u,
+    oddsLoose: 5 * u,
+    tier: {
+      sweet:  { passLine: 3 * u, come1: 2 * u, come2: 1 * u },
+      middle: { passLine: 2 * u, come1: 1 * u, come2: 1 * u },
+      rough:  { passLine: 1 * u, come1: 1 * u, come2: 1 * u },
+    },
+    buyAmount: 2 * u,
+    accumulatorStart: minPlaceBet(6, tableMin) + placeStep(6),
+    accumulatorRegressed: minPlaceBet(6, tableMin),
+    gates: {
+      littleMolly: 7 * u,
+      threePtMolly: 15 * u,
+      expandedAlpha: 25 * u,
+      maxAlpha: 40 * u,
+    },
+    modeShiftCushion: 20 * u,
+    hardReset: 2 * u,
+    classicRisk: 30 * u,
+    referenceFunded: {
+      tight: 20 * u,
+      littleMolly: 15 * u,
+    },
+  };
+}
+
+export interface BatsUnits {
+  tableMin: number;
+  unit: number;
+  /** Don't Pass / Don't Come flat: 1u. */
+  flat: number;
+  /** Lay-odds target win in the bearish Accumulator: 1u. */
+  layWinAccumulator: number;
+  /** Lay-odds target win in Little Dolly (and regressed-accumulator full mode): 2u. */
+  layWinDolly: number;
+  /** Lay-odds target win in 3-Point Dolly and above: 5u. */
+  layWinThreePt: number;
+  /** Standalone Lay 4/10/5/9 target win (Dark Alpha stages): 2u. */
+  layWinStandalone: number;
+  /** Profit gates (v1.x BATS ladder: $120/225/350/500 @ $10, scaled). */
+  gates: {
+    littleDolly: number;
+    threePtDolly: number;
+    expandedDarkAlpha: number;
+    maxDarkAlpha: number;
+  };
+}
+
+export function batsUnits(tableMin: number = 10): BatsUnits {
+  const u = tableMin;
+  return {
+    tableMin,
+    unit: u,
+    flat: u,
+    layWinAccumulator: u,
+    layWinDolly: 2 * u,
+    layWinThreePt: 5 * u,
+    layWinStandalone: 2 * u,
+    gates: {
+      littleDolly: Math.round(12 * u),
+      threePtDolly: Math.round(22.5 * u),
+      expandedDarkAlpha: Math.round(35 * u),
+      maxDarkAlpha: Math.round(50 * u),
+    },
+  };
+}

--- a/strategy/cats-strategy.md
+++ b/strategy/cats-strategy.md
@@ -515,7 +515,7 @@ At the table, ask one question: **Do I have a 6 or 8 working?**
 
 **Profit threshold step-down:** If profit falls below the current stage's entry threshold, step down immediately.
 
-**Hard reset:** If profit falls below +$20 from any stage, return to the Accumulator. Rebuild the buffer before committing Alpha load again.
+**Hard reset — retired (v1.3):** earlier revisions added a separate rule sending any stage straight to the Accumulator below +$20. It is retired as redundant: the step-down floors above already tile the whole profit range, so sustained losses reach the Accumulator through the normal chain from any stage — one mechanism instead of two, with the same endpoint. (Recorded as decision #3 in `docs/reqs/session-lifecycle.md`.)
 
 **Never chase:** A step-down is the strategy working. The Accumulator is always there. Return to it without hesitation.
 
@@ -556,6 +556,26 @@ The step-up and step-down thresholds are meaningless without a definition of wha
 
 ---
 
+## 3.8 Unit System
+
+All CATS sizing derives from the table minimum — one **unit (u)** = the table minimum; place bets use the smallest proper place bet at or above it. Rote phrasing: **gates at seven, fifteen, twenty-five, forty minimums; buys are two minimums; flats are one.**
+
+| Quantity | Canonical spec | $10 table | $15 table |
+|---|---|---|---|
+| Pass/Come flat | 1u | $10 | $15 |
+| Odds — Little Molly | 2× flat | $20 | $30 |
+| Odds — Loose | 5× flat | $50 | $75 |
+| Odds — Tight | tier 3×/2×/1× flat | $30/$20/$10 | $45/$30/$15 |
+| Accumulator start (each 6/8) | min place bet + $6 | $18 | $24 |
+| Accumulator regressed (each) | min place bet | $12 | $18 |
+| Buy 4/10, 5/9 (each) | 2u | $20 | $30 |
+| **Gates above origin** | **7 / 15 / 25 / 40 minimums** | $70/150/250/400 | $105/225/375/600 |
+| Classic declared risk B | 30u | $300 | $450 |
+
+The engine implements this as `src/dsl/units.ts`; the $10 column is the exact ladder this document has always specified.
+
+---
+
 # §4 Simulation Findings
 
 *CATS lives in a simulator repository; the strategy must answer to its own engine. This section reports what the repo's TypeScript engine shows about the ladder as specified — the numbers a player should know before choosing a buy-in and a session plan. The engine implements all five stages as `CATS()` in `src/dsl/strategies-staged.ts` (including the Swap Rule, §3.7 profit accounting, and the §3.4 step-down/hard-reset rules); the figures below come from `src/cli/analyze-stages.ts` over 2,000 sessions of up to 1,000 rolls at a $10 table with a $300 buy-in, sessions ending at ruin.*
@@ -591,6 +611,8 @@ Per-stage results from the same 2,000-session run (`analyze-stages.ts --strategy
 **Cost validation.** The engine's measured cost of the regressed Accumulator board is **$7.6 per 100 rolls** against the theoretical $7.8 (§1.4's come-out-adjusted Place 6/8 pair) — the anchor figure for the stage the strategy spends 80%+ of its time in. Bet-level payout math is pinned by the spec suite (Buy 4/10 at 1.67% and Buy 5/9 at 2.00% verified empirically over 200k resolutions each within ±0.3pp). Per-stage empirical E[loss] for the brief upper stages is not separately reportable with useful precision: their samples are small, concentrated in a handful of hot sessions, and the Swap Rule keeps part of the Buy load off the felt (which also means §2.5–2.6's ~$29 and ~$52 per-100-roll figures are ceilings — the working board is usually lighter than the fully-loaded one those figures assume).
 
 Threshold sensitivity (how stage-reach and P&L respond to moving the +$70/+$150/+$250 gates) is tracked separately — see `docs/cats-threshold-sensitivity.md`.
+
+**Funded entry is now simulatable:** the engine accepts `CATS@entry=<stage>` (any stage, any bankroll), setting profit's zero point so a session can begin mid-ladder — e.g. `CATS@entry=threePtMollyLoose` at $300 starts at Loose with a +$250 cushion declared. Side-by-side funded-vs-classic comparisons on identical dice run via `analyze-stages`; see `docs/analytics-guide.md`. Findings from those configurations are deliberately not written up here yet — that analysis is reserved for a separate revision.
 
 ---
 


### PR DESCRIPTION
Implements `docs/reqs/session-lifecycle.md` v4 in nine ordered commits: generalized funded entry, a table-minimum unit system, a streaming stopping-rule evaluator, multi-spec comparison, and manifest-based run identity. 795 specs green.

## What's in it

| Item | Commit | Delivered |
|---|---|---|
| 1 | `7522b7e` | **Unit system** (`src/dsl/units.ts`): every CATS/BATS sizing quantity derived from table minimum (`minPlaceBet` + "one rule"); dollar literals replaced; spec reproduces every v1.2 figure at $10 **and** $15 exactly |
| 2 | `e9607b5` | **`entryStage`** in the stage-machine core: `origin = B − gate(entry)`, `profit = equity − origin`; per-stage declarative entry metadata (slugs, display names, gates) |
| 3 | `e9dd168` | **Hard-reset retired** (v4 decision #3) — descent is purely the chained retreat floors; no-dead-zone floors-grid spec |
| 4 | `27afcf3` | **Canonical specs** `NAME@entry=…,tableMin=…` (round-trip stable), spec-aware `createStrategy`, `getStrategyMetadata` for generic UI entry dropdowns |
| 5 | `c123649` | **BATS acceptance**: `BATS@entry=threePtDolly` end-to-end with zero BATS-specific mechanism code |
| 6 | `36a7a09` | **Streaming stopping-rule menu**: none / targets k·B {2,3,6} / trailing floor / fall-below-stage / roll caps; trigger–ruin–censored rates, banked P&L, peak-capture, hitting probabilities, peak-P&L distribution |
| 7 | `ff3f521` | **Multi-spec comparison** on shared seeds (`--strategy` repeatable), side-by-side text + JSON array |
| 8 | `8f3bee4` | **Versioned manifest** embedded in all output modes; server in-memory LRU memoization keyed by manifest hash (no new deps; Firestore cache left as TODO); server never persists trajectories |
| 9 | `ae79edd` | **Docs**: `analytics-guide.md` I/O contracts (JSONL, report, stopping, manifest schemas); minimal `cats-strategy.md` sync (§3.8 unit table, hard-reset retirement note, §4 funded-entry pointer); v4 note marked approved with commit refs |

## Hard gates — both passed

- **Bit identity** (item 2): default-entry CATS JSONL byte-identical to the pre-Phase-3 commit across seeds 0–99 (300 rolls, $300); only normalization is the summary line's wall-clock timestamp. Reproducible via `scripts/bit-identity-check.sh`.
- **Dual path** (item 6): the streaming evaluator and an independent post-hoc truncation of archived JSONL match exactly at the mandated 500 seeds (`scripts/dual-path-check.ts`), plus in-suite equality on deterministic slices; rule `none` reproduces the session P&L metrics to the dollar.

## Behavior changes & flags

- **Hard-reset retirement** is the one deliberate behavior change (own commit, after the bit-identity gate).
- **Loose entry gate = 25u** (shared with expandedAlpha), per the work order's pinned example — an entry at exactly the gate plays one roll on the Loose board then advances; confirmed at the item-3 review checkpoint ("run with scissors"), recorded in the v4 note.
- **Fixed in passing, flagged**: all three server routes ran stage machines from registry singletons, leaking runtime state across seeds/requests (same bug class fixed in the CLI in Phase 2). Routes now instantiate fresh per session, making the server spec-aware (`strategy=CATS@entry=…`) with loud 400s on bad slugs; `/api/strategies?metadata=1` exposes stage metadata for the UI.

## Teaser (1,000 shared seeds, 300 rolls, $300)

| Metric | `CATS@entry=accumulator` | `CATS@entry=threePtMollyLoose` |
|---|---|---|
| P&L p10 / p50 / p90 | −$291 / −$63 / +$95 | −$298 / −$291 / **+$845** |
| Sessions positive / ruined | 31.5% / 13.5% | 18.2% / **62.8%** |
| P(hit 2B / 3B / 6B before ruin) | 18.6% / 9.0% / 1.9% | **43.4% / 29.0% / 11.0%** |

The funded Loose entry is the trade the ladder exists to defer: ~5× the ruin rate for a doubled-to-quintupled upside on every measure — and the stopping menu shows the two configs want different exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJJDtTN6Sr2aG1bqaMzNDw

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJJDtTN6Sr2aG1bqaMzNDw)_